### PR TITLE
feat(watch): ripple the standby splash

### DIFF
--- a/dist/watch.mjs
+++ b/dist/watch.mjs
@@ -1442,6 +1442,131 @@ function nodePanel(map, focusId, unicode, width, pinned, rows = PANEL_CONTENT_RO
   }
   return lines.slice(0, rows);
 }
+var SPLASH_FONT = {
+  M: ["#   #", "## ##", "# # #", "#   #", "#   #"],
+  E: ["####", "#", "###", "#", "####"],
+  L: ["#", "#", "#", "#", "####"],
+  O: [" ###", "#   #", "#   #", "#   #", " ###"],
+  S: [" ####", "#", " ###", "    #", "####"],
+  A: [" ###", "#   #", "#####", "#   #", "#   #"],
+  P: ["####", "#   #", "####", "#", "#"],
+  I: ["###", " #", " #", " #", "###"],
+  N: ["#   #", "##  #", "# # #", "#  ##", "#   #"],
+  G: [" ####", "#", "#  ##", "#   #", " ###"]
+};
+var SPLASH_ROWS = 5;
+var SPLASH_SHADES = {
+  unicode: ["\u2591", "\u2591", "\u2592", "\u2592", "\u2593", "\u2593", "\u2588", "\u2588"],
+  ascii: [".", ".", ":", ":", "=", "=", "#", "#"]
+};
+var WAVE_RAMP = [17, 18, 19, 61, 24, 25, 31, 37, 44, 45, 51, 87, 123, 159, 195];
+var SPINNER_FRAMES = {
+  unicode: ["\u280B", "\u2819", "\u2839", "\u2838", "\u283C", "\u2834", "\u2826", "\u2827", "\u2807", "\u280F"],
+  ascii: ["|", "/", "-", "\\"]
+};
+function wordArt(word) {
+  const glyphs = [...word.toUpperCase()].map((ch) => SPLASH_FONT[ch]).filter((g) => g !== void 0);
+  const widths = glyphs.map((g) => Math.max(...g.map((r) => r.length)));
+  const rows = [];
+  for (let r = 0; r < SPLASH_ROWS; r++) {
+    rows.push(glyphs.map((g, i) => (g[r] ?? "").padEnd(widths[i], " ")).join(" "));
+  }
+  return rows;
+}
+function splashArt() {
+  const words = [wordArt("MELLOS"), wordArt("MAPPING")];
+  const width = Math.max(...words.flat().map((r) => r.length));
+  const centered = words.map((rows) => {
+    const own = Math.max(...rows.map((r) => r.length));
+    return rows.map((r) => " ".repeat(Math.floor((width - own) / 2)) + r);
+  });
+  return [...centered[0], "", ...centered[1]];
+}
+var WAVE_INTERVAL = 18;
+var WAVE_LIFETIME = 64;
+var WAVE_SPEED = 0.9;
+var WAVE_ENVELOPE = 10;
+var WAVE_NUMBER = 0.42;
+var WAVE_LEVELS = 7;
+var WAVE_GAIN = 4.5;
+function waveHash(n) {
+  let h = Math.imul(n + 1, 2654435761) >>> 0;
+  h ^= h >>> 15;
+  h = Math.imul(h, 2246822519) >>> 0;
+  h ^= h >>> 13;
+  return h >>> 0;
+}
+var WAVE_CORNERS = [
+  [0, 0],
+  [1, 0],
+  [0, 1],
+  [1, 1]
+];
+function liveRipples(frame, width, height) {
+  const out = [];
+  const first = Math.floor((frame - WAVE_LIFETIME - WAVE_INTERVAL) / WAVE_INTERVAL);
+  const last = Math.floor(frame / WAVE_INTERVAL);
+  for (let n = Math.max(0, first); n <= last; n++) {
+    const h = waveHash(n);
+    const age = frame - (n * WAVE_INTERVAL + h % WAVE_INTERVAL);
+    if (age < 0 || age > WAVE_LIFETIME) continue;
+    const [fx, fy] = WAVE_CORNERS[h % WAVE_CORNERS.length];
+    out.push({
+      ox: fx * (width - 1),
+      oy: fy * (height - 1),
+      r: age * WAVE_SPEED,
+      fade: 1 - age / WAVE_LIFETIME
+    });
+  }
+  return out;
+}
+function waveAt(ripples, x, y) {
+  let value = 0;
+  for (const w of ripples) {
+    const front = Math.hypot(x - w.ox, (y - w.oy) * 2) - w.r;
+    value += Math.cos(front * WAVE_NUMBER) * Math.exp(-(front * front) / (2 * WAVE_ENVELOPE ** 2)) * w.fade;
+  }
+  return value;
+}
+function waveLevel(value) {
+  return Math.max(-WAVE_LEVELS, Math.min(WAVE_LEVELS, Math.round(value * WAVE_GAIN)));
+}
+function splashFrame(notice, frame, width, height, unicode, color) {
+  const art = splashArt();
+  const artWidth = Math.max(...art.map((r) => r.length));
+  if (width < artWidth + 2 || height < art.length + 2) return void 0;
+  const mode = unicode ? "unicode" : "ascii";
+  const shades = SPLASH_SHADES[mode];
+  const solid = shades[shades.length - 1];
+  const indent = " ".repeat(Math.floor((width - artWidth) / 2));
+  const ripples = liveRipples(frame, artWidth, art.length);
+  const inkOf = (x, y) => {
+    const level = waveLevel(waveAt(ripples, x, y));
+    return color ? `38;5;${WAVE_RAMP[WAVE_LEVELS + level]}` : shades[Math.abs(level)];
+  };
+  const paintRow = (row, y) => {
+    const cells = [...row].map((ch, x) => ch === "#" ? inkOf(x, y) : void 0);
+    let out = "";
+    for (let i = 0; i < cells.length; ) {
+      const cell = cells[i];
+      let j = i;
+      while (j < cells.length && cells[j] === cell) j++;
+      if (cell === void 0) out += " ".repeat(j - i);
+      else out += color ? `\x1B[${cell}m${solid.repeat(j - i)}${RESET}` : cell.repeat(j - i);
+      i = j;
+    }
+    return out;
+  };
+  const spinner = SPINNER_FRAMES[mode];
+  const status = fitWidth(`${spinner[frame % spinner.length]} ${notice}`, Math.max(1, width - 2));
+  const statusIndent = " ".repeat(Math.max(0, Math.floor((width - displayWidth(status)) / 2)));
+  const block = [
+    ...art.map((row, y) => row.trim() === "" ? "" : indent + paintRow(row, y)),
+    "",
+    statusIndent + (color ? `\x1B[90m${status}${RESET}` : status)
+  ];
+  return [...Array.from({ length: Math.max(0, Math.floor((height - block.length) / 2)) }, () => ""), ...block];
+}
 function mapPanel(map, unicode, width, rows = PANEL_CONTENT_ROWS) {
   const g = (s) => STATUS_GLYPH[s][unicode ? 0 : 1];
   const count = (s) => map.nodes.filter((n) => n.status === s).length;
@@ -1466,6 +1591,7 @@ function main() {
   const mouseActive = interactive && cfg.mouse;
   let lastFrame = "";
   let spinnerFrame = 0;
+  let splashTick = 0;
   let map;
   let notice = `waiting for ${cfg.file} ...`;
   let lastCols = process.stdout.columns ?? 0;
@@ -1567,7 +1693,7 @@ function main() {
       lastContent = { w: windowed.contentWidth, h: windowed.contentHeight };
       if (offsetX !== 0 || offsetY !== 0) panned = `  (+${offsetX},+${offsetY})`;
     } else {
-      body = [fitWidth(notice, Math.max(1, cols - 1))];
+      body = (interactive ? splashFrame(notice, splashTick, cols, viewH, cfg.unicode, cfg.color) : void 0) ?? [fitWidth(notice, Math.max(1, cols - 1))];
     }
     if (notice !== "" && map !== void 0) {
       body[body.length - 1] = fitWidth(`  ${notice}`, Math.max(1, cols - 1));
@@ -1854,6 +1980,13 @@ function main() {
   }
   tick();
   setInterval(tick, cfg.intervalMs);
+  if (interactive) {
+    setInterval(() => {
+      if (map !== void 0) return;
+      splashTick++;
+      paint();
+    }, 80);
+  }
 }
 function launchedAsEntry(argv1, moduleUrl) {
   if (argv1 === void 0) return false;
@@ -1868,17 +2001,26 @@ if (launchedAsEntry(process.argv[1], import.meta.url)) {
 }
 export {
   PANEL_ROWS_MIN,
+  WAVE_LEVELS,
+  WAVE_NUMBER,
   anchorOffsets,
   clampPanelRows,
   diveOrigin,
   fitWidth,
   launchedAsEntry,
+  liveRipples,
   mapPanel,
   nearestHit,
   nodePanel,
   pageTabRow,
   panelRowsFromDividerY,
   parseArgs,
+  splashArt,
+  splashFrame,
   topLevelFiles,
+  waveAt,
+  waveHash,
+  waveLevel,
+  wordArt,
   wrapWidth
 };

--- a/src/watch/watch.test.ts
+++ b/src/watch/watch.test.ts
@@ -31,7 +31,17 @@ import {
   nodePanel,
   pageTabRow,
   panelRowsFromDividerY,
+  type Ripple,
+  WAVE_LEVELS,
+  WAVE_NUMBER,
+  liveRipples,
+  splashArt,
+  splashFrame,
   topLevelFiles,
+  waveAt,
+  waveHash,
+  waveLevel,
+  wordArt,
   wrapWidth,
 } from './watch.js';
 
@@ -297,5 +307,128 @@ describe('zoom anchoring', () => {
     const hits = [hit('far', 50, 20), hit('near', 10, 5)];
     expect(nearestHit(hits, 12, 6)?.id).toBe('near');
     expect(nearestHit([], 12, 6)).toBeUndefined();
+  });
+});
+
+describe('standby splash', () => {
+  const strip = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, '');
+
+  it('sets every word row to the same width in the block font', () => {
+    const rows = wordArt('MELLOS');
+    expect(rows).toHaveLength(5);
+    expect(new Set(rows.map((r) => r.length)).size).toBe(1);
+    expect(rows.join('')).toContain('#');
+  });
+
+  it('stacks both words centered on each other, blank line between', () => {
+    const art = splashArt();
+    expect(art).toHaveLength(11);
+    expect(art[5]).toBe('');
+    // MAPPING is the wider word, so it sets the block width and starts flush
+    expect(art[6]!.startsWith(' ')).toBe(false);
+    expect(art[0]!.startsWith(' ')).toBe(true);
+  });
+
+  it('rolls the same corners and jitters on every run', () => {
+    expect(waveHash(7)).toBe(waveHash(7));
+    expect(waveHash(7)).not.toBe(waveHash(8));
+    // over a long run every corner gets used
+    const corners = new Set(Array.from({ length: 60 }, (_, n) => waveHash(n) % 4));
+    expect([...corners].sort()).toEqual([0, 1, 2, 3]);
+  });
+
+  it('keeps a steady population of rings, each expanding and fading', () => {
+    expect(liveRipples(0, 40, 11).length).toBeLessThanOrEqual(1); // water starts still
+    const rings = liveRipples(200, 40, 11);
+    expect(rings.length).toBeGreaterThanOrEqual(2);
+    expect(rings.length).toBeLessThanOrEqual(6);
+    // oldest first: the widest ring is also the faintest
+    expect(rings[0]!.r).toBeGreaterThan(rings.at(-1)!.r);
+    expect(rings[0]!.fade).toBeLessThan(rings.at(-1)!.fade);
+    for (const r of rings) expect(r.fade).toBeGreaterThanOrEqual(0);
+  });
+
+  it('superposes rings: crests reinforce, a crest meets a trough and cancels', () => {
+    const ring = (r: number): Ripple => ({ ox: 0, oy: 0, r, fade: 1 });
+    const crest = waveAt([ring(10)], 10, 0); // cell sits exactly on the front
+    expect(crest).toBeCloseTo(1, 5);
+    expect(waveAt([ring(10), ring(10)], 10, 0)).toBeCloseTo(2, 5);
+    // a ring whose front trails by half a wavelength arrives in antiphase
+    expect(Math.abs(waveAt([ring(10), ring(10 - Math.PI / WAVE_NUMBER)], 10, 0))).toBeLessThan(crest);
+  });
+
+  it('keeps the top of the ramp out of reach for a lone ring', () => {
+    const ring = (r: number): Ripple => ({ ox: 0, oy: 0, r, fade: 1 });
+    const alone = waveLevel(waveAt([ring(10)], 10, 0));
+    expect(alone).toBeGreaterThan(0);
+    expect(alone).toBeLessThan(WAVE_LEVELS); // only a pile-up reaches the glare
+    expect(waveLevel(waveAt([ring(10), ring(10)], 10, 0))).toBe(WAVE_LEVELS);
+  });
+
+  it('quantizes surface height into the ramp, clamping the extremes', () => {
+    expect(waveLevel(0)).toBe(0);
+    expect(waveLevel(5)).toBe(WAVE_LEVELS);
+    expect(waveLevel(-5)).toBe(-WAVE_LEVELS);
+    expect(waveLevel(-0.5)).toBe(-2);
+  });
+
+  it('gives up on a pane too small for the art', () => {
+    expect(splashFrame('waiting', 0, 20, 40, true, true)).toBeUndefined();
+    expect(splashFrame('waiting', 0, 80, 6, true, true)).toBeUndefined();
+  });
+
+  it('centers the art and the notice inside the viewport', () => {
+    const frame = splashFrame('waiting for map.json', 0, 60, 30, true, false)!;
+    expect(frame.length).toBeLessThanOrEqual(30);
+    const notice = frame.at(-1)!;
+    expect(notice).toContain('waiting for map.json');
+    expect(notice.startsWith(' ')).toBe(true);
+    const inked = frame.filter((r) => /[░▒▓█]/.test(r));
+    expect(inked).toHaveLength(10); // 5 rows per word, blank divider excluded
+  });
+
+  it('animates without color by shading the ink instead', () => {
+    const a = splashFrame('waiting', 40, 60, 30, false, false)!.join('\n');
+    const b = splashFrame('waiting', 90, 60, 30, false, false)!.join('\n');
+    expect(a).not.toContain('\x1b[');
+    expect(a).not.toBe(b);
+    expect(a).toMatch(/[#=:.]/);
+  });
+
+  it('rides the 256-color ramps and keeps the ink solid when color is on', () => {
+    const art = (frame: number): string[] => splashFrame('waiting', frame, 60, 30, true, true)!.slice(0, -1);
+    const a = art(40).join('\n');
+    const b = art(90).join('\n');
+    expect(a).toContain('\x1b[38;5;');
+    expect(a).not.toBe(b);
+    // color mode never shades: stripped of ANSI the two art frames are identical
+    expect(strip(a)).toBe(strip(b));
+  });
+
+  it('paints only from the one ramp — no color can appear off-palette', () => {
+    const ramp = new Set([17, 18, 19, 61, 24, 25, 31, 37, 44, 45, 51, 87, 123, 159, 195]);
+    for (let f = 0; f < 200; f += 7) {
+      const codes = splashFrame('waiting', f, 60, 30, true, true)!.join('\n').matchAll(/38;5;(\d+)/g);
+      for (const m of codes) expect(ramp.has(Number(m[1]))).toBe(true);
+    }
+  });
+
+  it('reads as a gradient, not confetti: touching ink cells stay close on the ramp', () => {
+    // Measured on the field itself — consecutive color runs in a painted row
+    // can sit cells apart, because letter strokes have gaps between them.
+    const art = splashArt();
+    const width = Math.max(...art.map((r) => r.length));
+    let widest = 0;
+    for (let f = 0; f < 400; f++) {
+      const rings = liveRipples(f, width, art.length);
+      for (const [y, row] of art.entries()) {
+        for (let x = 1; x < row.length; x++) {
+          if (row[x] !== '#' || row[x - 1] !== '#') continue;
+          const step = Math.abs(waveLevel(waveAt(rings, x, y)) - waveLevel(waveAt(rings, x - 1, y)));
+          widest = Math.max(widest, step);
+        }
+      }
+    }
+    expect(widest).toBeLessThanOrEqual(3);
   });
 });

--- a/src/watch/watch.ts
+++ b/src/watch/watch.ts
@@ -408,6 +408,220 @@ export function nodePanel(
   return lines.slice(0, rows);
 }
 
+/**
+ * The standby splash — what the pane shows before any map exists.
+ *
+ * A 5-row block font, two stacked words, lit by ripples. Waves are born at
+ * a randomized corner every WAVE_INTERVAL frames and expand as damped rings;
+ * the ink of a cell is the SUM of every live ring over it, so overlapping
+ * waves interfere for real — crests reinforce, a crest meeting a trough
+ * cancels back to still water. Surface height drives one continuous
+ * indigo→cyan→white ramp, and the gain is set so the top of that ramp is
+ * out of reach for a lone ring: the near-white glare only happens where
+ * waves actually pile up. Without color the same field shades the ink
+ * instead, so a --no-color --ascii pane still ripples.
+ *
+ * Everything here is a pure function of `frame` — no Math.random, so the
+ * animation is reproducible and testable.
+ */
+const SPLASH_FONT: Readonly<Record<string, readonly string[]>> = {
+  M: ['#   #', '## ##', '# # #', '#   #', '#   #'],
+  E: ['####', '#', '###', '#', '####'],
+  L: ['#', '#', '#', '#', '####'],
+  O: [' ###', '#   #', '#   #', '#   #', ' ###'],
+  S: [' ####', '#', ' ###', '    #', '####'],
+  A: [' ###', '#   #', '#####', '#   #', '#   #'],
+  P: ['####', '#   #', '####', '#', '#'],
+  I: ['###', ' #', ' #', ' #', '###'],
+  N: ['#   #', '##  #', '# # #', '#  ##', '#   #'],
+  G: [' ####', '#', '#  ##', '#   #', ' ###'],
+};
+const SPLASH_ROWS = 5;
+
+/** Ink shades by |level| 0..WAVE_LEVELS for the no-color path. */
+const SPLASH_SHADES: Readonly<Record<'unicode' | 'ascii', readonly string[]>> = {
+  unicode: ['░', '░', '▒', '▒', '▓', '▓', '█', '█'],
+  ascii: ['.', '.', ':', ':', '=', '=', '#', '#'],
+};
+/**
+ * One continuous xterm-256 ramp, deep trough to high crest, indexed by
+ * WAVE_LEVELS + level. Monotonic in lightness and confined to indigo→cyan→white
+ * so neighbouring cells are always neighbouring colors: the ripple reads as a
+ * gradient over the letters instead of confetti. Still water sits mid-ramp.
+ */
+const WAVE_RAMP: readonly number[] = [17, 18, 19, 61, 24, 25, 31, 37, 44, 45, 51, 87, 123, 159, 195];
+const SPINNER_FRAMES: Readonly<Record<'unicode' | 'ascii', readonly string[]>> = {
+  unicode: ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'],
+  ascii: ['|', '/', '-', '\\'],
+};
+
+/** One word in the block font: SPLASH_ROWS lines of '#' ink on spaces. */
+export function wordArt(word: string): string[] {
+  const glyphs = [...word.toUpperCase()]
+    .map((ch) => SPLASH_FONT[ch])
+    .filter((g): g is readonly string[] => g !== undefined);
+  const widths = glyphs.map((g) => Math.max(...g.map((r) => r.length)));
+  const rows: string[] = [];
+  for (let r = 0; r < SPLASH_ROWS; r++) {
+    rows.push(glyphs.map((g, i) => (g[r] ?? '').padEnd(widths[i]!, ' ')).join(' '));
+  }
+  return rows;
+}
+
+/** Both words stacked and mutually centered, blank line between. */
+export function splashArt(): string[] {
+  const words = [wordArt('MELLOS'), wordArt('MAPPING')];
+  const width = Math.max(...words.flat().map((r) => r.length));
+  const centered = words.map((rows) => {
+    const own = Math.max(...rows.map((r) => r.length));
+    return rows.map((r) => ' '.repeat(Math.floor((width - own) / 2)) + r);
+  });
+  return [...centered[0]!, '', ...centered[1]!];
+}
+
+/**
+ * frames between births · frames a ring survives · art columns per frame.
+ * Tuned so three or four rings share the water: enough for collisions to
+ * happen often, few enough that the picture still reads as waves.
+ */
+const WAVE_INTERVAL = 18;
+const WAVE_LIFETIME = 64;
+const WAVE_SPEED = 0.9;
+/** Ring half-width in cells, and the angular wavenumber of its lobes. */
+const WAVE_ENVELOPE = 10;
+export const WAVE_NUMBER = 0.42;
+/**
+ * Levels either side of still water, and the surface-height-to-level gain.
+ * The gain is deliberately short of the top: one ring alone peaks around
+ * level 5, so the last two rungs of the ramp — the near-white glare — can
+ * only be reached where rings actually pile onto each other.
+ */
+export const WAVE_LEVELS = 7;
+const WAVE_GAIN = 4.5;
+
+/**
+ * Deterministic scramble standing in for a die roll — wave `n` always picks
+ * the same corner and the same birth jitter, on every machine and every run.
+ */
+export function waveHash(n: number): number {
+  let h = Math.imul(n + 1, 2654435761) >>> 0;
+  h ^= h >>> 15;
+  h = Math.imul(h, 2246822519) >>> 0;
+  h ^= h >>> 13;
+  return h >>> 0;
+}
+
+/** Corner origins as (x, y) fractions of the art block: TL, TR, BL, BR. */
+const WAVE_CORNERS: readonly (readonly [number, number])[] = [
+  [0, 0],
+  [1, 0],
+  [0, 1],
+  [1, 1],
+];
+
+export interface Ripple {
+  readonly ox: number;
+  readonly oy: number;
+  /** current radius of the ring front */
+  readonly r: number;
+  /** 1 at birth, 0 at the end of life */
+  readonly fade: number;
+}
+
+/** Every ring alive at `frame`, oldest first. */
+export function liveRipples(frame: number, width: number, height: number): Ripple[] {
+  const out: Ripple[] = [];
+  // a birth jitters up to WAVE_INTERVAL-1 frames late, so scan one slot wider
+  const first = Math.floor((frame - WAVE_LIFETIME - WAVE_INTERVAL) / WAVE_INTERVAL);
+  const last = Math.floor(frame / WAVE_INTERVAL);
+  for (let n = Math.max(0, first); n <= last; n++) {
+    const h = waveHash(n);
+    const age = frame - (n * WAVE_INTERVAL + (h % WAVE_INTERVAL));
+    if (age < 0 || age > WAVE_LIFETIME) continue;
+    const [fx, fy] = WAVE_CORNERS[h % WAVE_CORNERS.length]!;
+    out.push({
+      ox: fx * (width - 1),
+      oy: fy * (height - 1),
+      r: age * WAVE_SPEED,
+      fade: 1 - age / WAVE_LIFETIME,
+    });
+  }
+  return out;
+}
+
+/**
+ * Superpose the rings over one cell into a signed surface height: + crest,
+ * - trough, ~0 still water or two rings cancelling. Rows are half the height
+ * of columns in a terminal cell, so y is doubled to keep the rings round.
+ */
+export function waveAt(ripples: readonly Ripple[], x: number, y: number): number {
+  let value = 0;
+  for (const w of ripples) {
+    const front = Math.hypot(x - w.ox, (y - w.oy) * 2) - w.r;
+    value += Math.cos(front * WAVE_NUMBER) * Math.exp(-(front * front) / (2 * WAVE_ENVELOPE ** 2)) * w.fade;
+  }
+  return value;
+}
+
+/** Quantize surface height to a ramp index in [-WAVE_LEVELS, WAVE_LEVELS]. */
+export function waveLevel(value: number): number {
+  return Math.max(-WAVE_LEVELS, Math.min(WAVE_LEVELS, Math.round(value * WAVE_GAIN)));
+}
+
+/**
+ * The full standby frame, centered in a `width` x `height` viewport, ANSI
+ * already applied. Returns undefined when the pane is too small for the art —
+ * the caller then falls back to the plain one-line notice.
+ */
+export function splashFrame(
+  notice: string,
+  frame: number,
+  width: number,
+  height: number,
+  unicode: boolean,
+  color: boolean,
+): string[] | undefined {
+  const art = splashArt();
+  const artWidth = Math.max(...art.map((r) => r.length));
+  if (width < artWidth + 2 || height < art.length + 2) return undefined;
+
+  const mode = unicode ? 'unicode' : 'ascii';
+  const shades = SPLASH_SHADES[mode];
+  const solid = shades[shades.length - 1]!;
+  const indent = ' '.repeat(Math.floor((width - artWidth) / 2));
+  const ripples = liveRipples(frame, artWidth, art.length);
+
+  /** The paint of one ink cell: a 256-color code, or a shade char without color. */
+  const inkOf = (x: number, y: number): string => {
+    const level = waveLevel(waveAt(ripples, x, y));
+    return color ? `38;5;${WAVE_RAMP[WAVE_LEVELS + level]!}` : shades[Math.abs(level)]!;
+  };
+
+  const paintRow = (row: string, y: number): string => {
+    const cells = [...row].map((ch, x) => (ch === '#' ? inkOf(x, y) : undefined));
+    let out = '';
+    for (let i = 0; i < cells.length; ) {
+      const cell = cells[i];
+      let j = i;
+      while (j < cells.length && cells[j] === cell) j++;
+      if (cell === undefined) out += ' '.repeat(j - i);
+      else out += color ? `\x1b[${cell}m${solid.repeat(j - i)}${RESET}` : cell.repeat(j - i);
+      i = j;
+    }
+    return out;
+  };
+
+  const spinner = SPINNER_FRAMES[mode];
+  const status = fitWidth(`${spinner[frame % spinner.length]!} ${notice}`, Math.max(1, width - 2));
+  const statusIndent = ' '.repeat(Math.max(0, Math.floor((width - displayWidth(status)) / 2)));
+  const block = [
+    ...art.map((row, y) => (row.trim() === '' ? '' : indent + paintRow(row, y))),
+    '',
+    statusIndent + (color ? `\x1b[90m${status}${RESET}` : status),
+  ];
+  return [...Array.from({ length: Math.max(0, Math.floor((height - block.length) / 2)) }, () => ''), ...block];
+}
+
 /** The dashboard shown when nothing is focused. Exactly `rows` lines. */
 export function mapPanel(
   map: MellosMap,
@@ -443,6 +657,7 @@ function main(): void {
 
   let lastFrame = '';
   let spinnerFrame = 0;
+  let splashTick = 0;
   let map: MellosMap | undefined;
   let notice = `waiting for ${cfg.file} ...`;
   let lastCols = process.stdout.columns ?? 0;
@@ -576,7 +791,11 @@ function main(): void {
       lastContent = { w: windowed.contentWidth, h: windowed.contentHeight };
       if (offsetX !== 0 || offsetY !== 0) panned = `  (+${offsetX},+${offsetY})`;
     } else {
-      body = [fitWidth(notice, Math.max(1, cols - 1))];
+      // No map yet: the standby splash, but only on a real TTY — a piped run
+      // must not stream an animation, so it keeps the one-line notice.
+      body =
+        (interactive ? splashFrame(notice, splashTick, cols, viewH, cfg.unicode, cfg.color) : undefined) ??
+        [fitWidth(notice, Math.max(1, cols - 1))];
     }
     if (notice !== '' && map !== undefined) {
       body[body.length - 1] = fitWidth(`  ${notice}`, Math.max(1, cols - 1));
@@ -921,6 +1140,15 @@ function main(): void {
 
   tick();
   setInterval(tick, cfg.intervalMs);
+  // The splash sweep runs faster than the file poll — its own timer, idle
+  // (one comparison) the moment a map exists.
+  if (interactive) {
+    setInterval(() => {
+      if (map !== undefined) return;
+      splashTick++;
+      paint();
+    }, 80);
+  }
 }
 
 /**


### PR DESCRIPTION
The pane's pre-map screen was a single line of text. It now shows a **MELLOS / MAPPING** wordmark in a 5-row block font, lit by interfering ripples.

## How it works

Waves are born at a randomized corner every 18 frames and expand as damped rings. A cell's ink is the algebraic **sum** of every live ring over it, so the waves interfere for real:

```
push = cos(front · k) · exp(−front² / 2σ²) · fade
```

Crests reinforce, a crest meeting a trough cancels back to still water. Surface height drives one continuous indigo→cyan→white ramp, and the gain stops short of the top — a lone ring peaks around level 5 of 7, so the near-white glare is only reachable where rings actually pile up. Collision color falls out of the physics rather than a per-cell special case.

(The first cut used three separate hue families keyed off an overlap count. Adjacent cells jumped cyan → gold → magenta and it read as confetti, not water. The single monotonic ramp replaced it.)

## Details

- **No `Math.random`.** Corners and birth jitter come from an integer scramble of the wave index, so a given frame paints identically on every machine — and is testable.
- Distance is `hypot(dx, dy·2)` to compensate for the 1:2 aspect of a terminal cell, or the rings render as ellipses.
- The sweep has its own 80 ms timer (the file poll stays at 250 ms), idle the moment a map exists.
- **TTY only.** A piped/CI run keeps the plain one-line notice instead of streaming an animation, as do panes too small for the art.
- Without color the same field drives shade characters, so `--no-color --ascii` still ripples.

## Tests

`npm run verify` green — typecheck clean, **165 passed**, build OK. Eight new cases cover the block font, centering, corner coverage and reproducibility, ring population/expansion/decay, superposition and antiphase cancellation, the unreachable-alone top of the ramp, and two that guard the look:

- nothing may render off-palette
- touching ink cells stay within 3 rungs of each other (measured on the field, since consecutive color runs in a painted row can sit cells apart across letter gaps; distribution is `{0: 12758, 1: 10214, 2: 1017, 3: 11}`)

`dist/watch.mjs` is rebuilt and included, matching how the repo tracks build output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)