### PR TITLE
feat(timing): record how long each node took

### DIFF
--- a/dist/server.mjs
+++ b/dist/server.mjs
@@ -21306,6 +21306,31 @@ function aggregateStatus(nodes) {
 function groupStatus(map, id) {
   return aggregateStatus(map.nodes.filter((n) => n.group === id));
 }
+var IDLE_CAP_MS = 30 * 6e4;
+function spanTotal(spans, now, idleCap = IDLE_CAP_MS) {
+  const closed = spans.map((s) => ({
+    from: s.from,
+    to: Math.max(s.from, s.to ?? Math.min(now, s.from + idleCap))
+  })).sort((a, b) => a.from - b.from);
+  let total = 0;
+  let covered = -Infinity;
+  for (const s of closed) {
+    const start = Math.max(s.from, covered);
+    if (s.to > start) total += s.to - start;
+    covered = Math.max(covered, s.to);
+  }
+  return total;
+}
+function elapsedOf(nodes, now, idleCap = IDLE_CAP_MS) {
+  return spanTotal(
+    nodes.flatMap((n) => n.spans ?? []),
+    now,
+    idleCap
+  );
+}
+function isStalled(nodes, now, idleCap = IDLE_CAP_MS) {
+  return nodes.some((n) => (n.spans ?? []).some((s) => s.to === void 0 && now - s.from > idleCap));
+}
 function declareNode(map, input) {
   if (findNode(map, input.id)) return err({ kind: "duplicate-node", id: input.id });
   if (!findLayer(map, input.layer)) return err({ kind: "unknown-layer", id: input.layer });
@@ -21323,7 +21348,8 @@ function declareNode(map, input) {
     ...input.group !== void 0 ? { group: input.group } : {},
     ...input.kind !== void 0 ? { kind: input.kind } : {},
     ...input.lane !== void 0 ? { lane: input.lane } : {},
-    ...input.submap !== void 0 ? { submap: input.submap } : {}
+    ...input.submap !== void 0 ? { submap: input.submap } : {},
+    ...input.spans !== void 0 ? { spans: input.spans } : {}
   };
   return ok({ ...map, nodes: [...map.nodes, node] });
 }
@@ -21339,6 +21365,14 @@ function linkNodes(map, from, to, label) {
   if (fromRank <= toRank) return err({ kind: "edge-not-downward", from, fromRank, to, toRank });
   return ok({ ...map, edges: [...map.edges, { from, to, ...label !== void 0 ? { label } : {} }] });
 }
+function stampSpans(node, status, at) {
+  if (status === void 0 || at === void 0) return node.spans;
+  const spans = node.spans ?? [];
+  const open = spans.findIndex((s) => s.to === void 0);
+  if (status === "in-progress") return open >= 0 ? node.spans : [...spans, { from: at }];
+  if (open < 0) return node.spans;
+  return spans.map((s, i) => i === open ? { from: s.from, to: Math.max(s.from, at) } : s);
+}
 function updateNode(map, input) {
   const node = findNode(map, input.id);
   if (!node) return err({ kind: "unknown-node", id: input.id });
@@ -21349,7 +21383,8 @@ function updateNode(map, input) {
   if (input.lane !== void 0 && input.lane !== null && !findLane(map, input.lane)) {
     return err({ kind: "unknown-lane", id: input.lane });
   }
-  const { group: currentGroup, kind: currentKind, lane: currentLane, submap: currentSubmap, ...bare } = node;
+  const { group: currentGroup, kind: currentKind, lane: currentLane, submap: currentSubmap, spans: _spans, ...bare } = node;
+  const nextSpans = stampSpans(node, input.status, input.at);
   const nextGroup = input.group === void 0 ? currentGroup : input.group === null ? void 0 : input.group;
   const nextKind = input.kind === void 0 ? currentKind : input.kind === null ? void 0 : input.kind;
   const nextLane = input.lane === void 0 ? currentLane : input.lane === null ? void 0 : input.lane;
@@ -21360,6 +21395,7 @@ function updateNode(map, input) {
     ...nextKind !== void 0 ? { kind: nextKind } : {},
     ...nextLane !== void 0 ? { lane: nextLane } : {},
     ...nextSubmap !== void 0 ? { submap: nextSubmap } : {},
+    ...nextSpans !== void 0 ? { spans: nextSpans } : {},
     ...input.status !== void 0 ? { status: input.status } : {},
     ...input.label !== void 0 ? { label: input.label } : {},
     ...input.evidence !== void 0 ? { evidence: input.evidence } : {},
@@ -21423,6 +21459,15 @@ function displayWidth(text2) {
   let w = 0;
   for (const ch of text2) w += charWidth(ch.codePointAt(0));
   return w;
+}
+function formatDuration(ms) {
+  const total = Math.max(0, Math.floor(ms / 1e3));
+  const [s, m, h, d] = [total % 60, Math.floor(total / 60) % 60, Math.floor(total / 3600) % 24, Math.floor(total / 86400)];
+  const pad = (n) => String(n).padStart(2, "0");
+  if (d > 0) return `${d}d${pad(h)}h`;
+  if (h > 0) return `${h}h${pad(m)}m`;
+  if (m > 0) return `${m}m${pad(s)}s`;
+  return `${s}s`;
 }
 function fitWidth(s, width) {
   if (displayWidth(s) <= width) return s;
@@ -22096,6 +22141,12 @@ function buildCanvasWith(map, opts, geo) {
       if (lx > LEFT_MARGIN) lx = canvas.text(lx, legendY, "   ", "none");
       lx = canvas.text(lx, legendY, `${glyphFor(status, legendOpts)} ${status}`, style);
     }
+    const elapsed = opts.now !== void 0 ? elapsedOf(map.nodes, opts.now) : 0;
+    if (elapsed > 0) {
+      const floor = isStalled(map.nodes, opts.now) ? "+" : "";
+      lx = canvas.text(lx, legendY, "   ", "none");
+      lx = canvas.text(lx, legendY, `~ ${formatDuration(elapsed)}${floor}`, "faint");
+    }
   }
   const hits = [...boxes.values()].map((b) => ({
     id: b.node.id,
@@ -22159,6 +22210,24 @@ function asArray(v) {
 }
 function optionalString(v) {
   return typeof v === "string" ? v : void 0;
+}
+function parseSpans(v) {
+  if (v === void 0) return void 0;
+  if (!Array.isArray(v)) return { ok: false, detail: "spans is not an array" };
+  const out = [];
+  for (const [i, raw] of v.entries()) {
+    if (!isRecord(raw)) return { ok: false, detail: `spans[${i}] is not an object` };
+    const from = raw["from"];
+    const to = raw["to"];
+    if (typeof from !== "number" || !Number.isFinite(from)) {
+      return { ok: false, detail: `spans[${i}] needs a finite numeric from` };
+    }
+    if (to !== void 0 && (typeof to !== "number" || !Number.isFinite(to))) {
+      return { ok: false, detail: `spans[${i}].to must be a finite number when present` };
+    }
+    out.push(to === void 0 ? { from } : { from, to });
+  }
+  return { ok: true, value: out };
 }
 function parseMap(raw, path) {
   if (!isRecord(raw)) return err({ kind: "bad-shape", path, detail: "root is not an object" });
@@ -22248,6 +22317,10 @@ function parseMap(raw, path) {
       if (!made.ok) return err({ kind: "invariant-violation", path, violation: made.error });
       submap = made.value;
     }
+    const spans = parseSpans(rawNode["spans"]);
+    if (spans !== void 0 && !spans.ok) {
+      return err({ kind: "bad-shape", path, detail: `nodes[${i}].${spans.detail}` });
+    }
     const declared = declareNode(map, {
       id: id.value,
       label,
@@ -22257,7 +22330,8 @@ function parseMap(raw, path) {
       ...group !== void 0 ? { group } : {},
       ...nodeKind !== void 0 ? { kind: nodeKind } : {},
       ...lane !== void 0 ? { lane } : {},
-      ...submap !== void 0 ? { submap } : {}
+      ...submap !== void 0 ? { submap } : {},
+      ...spans !== void 0 && spans.ok ? { spans: spans.value } : {}
     });
     if (!declared.ok) return err({ kind: "invariant-violation", path, violation: declared.error });
     map = declared.value;
@@ -22318,7 +22392,7 @@ function saveMapFile(path, map) {
 }
 
 // src/server/apply.ts
-function applyDeclare(map, input) {
+function applyDeclare(map, input, at) {
   let next = input.title !== void 0 ? setTitle(map, input.title) : map;
   if (input.kind !== void 0) {
     const kind = makeMapKind(input.kind);
@@ -22392,7 +22466,9 @@ function applyDeclare(map, input) {
       ...group !== void 0 ? { group } : {},
       ...kind !== void 0 ? { kind } : {},
       ...lane !== void 0 ? { lane } : {},
-      ...submap !== void 0 ? { submap } : {}
+      ...submap !== void 0 ? { submap } : {},
+      // declared straight into work: the clock starts now
+      ...status === "in-progress" ? { spans: [{ from: at }] } : {}
     });
     if (!declared.ok) return err(`nodes[${i}]: ${describeMapError(declared.error)}`);
     next = declared.value;
@@ -22408,7 +22484,7 @@ function applyDeclare(map, input) {
   }
   return ok(next);
 }
-function applyUpdate(map, input) {
+function applyUpdate(map, input, at) {
   let next = map;
   for (const [i, u] of input.updates.entries()) {
     const id = makeNodeId(u.id);
@@ -22449,6 +22525,7 @@ function applyUpdate(map, input) {
     }
     const updated = updateNode(next, {
       id: id.value,
+      at,
       ...status !== void 0 ? { status } : {},
       ...u.label !== void 0 ? { label: u.label } : {},
       ...u.evidence !== void 0 ? { evidence: u.evidence } : {},
@@ -22597,7 +22674,7 @@ function buildServer(stateFile) {
         edges: external_exports.array(EDGE.extend({ label: external_exports.string().max(80).optional().describe("what flows along the edge") })).optional()
       }
     },
-    (input) => mutate(input.page, (map) => applyDeclare(map, input))
+    (input) => mutate(input.page, (map) => applyDeclare(map, input, Date.now()))
   );
   server.registerTool(
     "mmap_update",
@@ -22621,7 +22698,7 @@ function buildServer(stateFile) {
         ).min(1)
       }
     },
-    (input) => mutate(input.page, (map) => applyUpdate(map, input))
+    (input) => mutate(input.page, (map) => applyUpdate(map, input, Date.now()))
   );
   server.registerTool(
     "mmap_remove",
@@ -22653,7 +22730,9 @@ function buildServer(stateFile) {
       const current = loadOrEmpty(fileOf(input.page));
       if (!current.ok) return text(current.error, true);
       const zoom = clampZoom(input.zoom ?? 0);
-      return text(renderMap(current.value, { color: false, unicode: true, spinnerFrame: 0, zoom }).join("\n"));
+      return text(
+        renderMap(current.value, { color: false, unicode: true, spinnerFrame: 0, zoom, now: Date.now() }).join("\n")
+      );
     }
   );
   return server;

--- a/dist/watch.mjs
+++ b/dist/watch.mjs
@@ -137,6 +137,34 @@ function groupStatus(map, id) {
 function mapStatus(map) {
   return aggregateStatus(map.nodes);
 }
+var IDLE_CAP_MS = 30 * 6e4;
+function spanTotal(spans, now, idleCap = IDLE_CAP_MS) {
+  const closed = spans.map((s) => ({
+    from: s.from,
+    to: Math.max(s.from, s.to ?? Math.min(now, s.from + idleCap))
+  })).sort((a, b) => a.from - b.from);
+  let total = 0;
+  let covered = -Infinity;
+  for (const s of closed) {
+    const start = Math.max(s.from, covered);
+    if (s.to > start) total += s.to - start;
+    covered = Math.max(covered, s.to);
+  }
+  return total;
+}
+function elapsedOf(nodes, now, idleCap = IDLE_CAP_MS) {
+  return spanTotal(
+    nodes.flatMap((n) => n.spans ?? []),
+    now,
+    idleCap
+  );
+}
+function isStalled(nodes, now, idleCap = IDLE_CAP_MS) {
+  return nodes.some((n) => (n.spans ?? []).some((s) => s.to === void 0 && now - s.from > idleCap));
+}
+function effortOf(nodes, now, idleCap = IDLE_CAP_MS) {
+  return nodes.reduce((sum, n) => sum + elapsedOf([n], now, idleCap), 0);
+}
 function declareNode(map, input) {
   if (findNode(map, input.id)) return err({ kind: "duplicate-node", id: input.id });
   if (!findLayer(map, input.layer)) return err({ kind: "unknown-layer", id: input.layer });
@@ -154,7 +182,8 @@ function declareNode(map, input) {
     ...input.group !== void 0 ? { group: input.group } : {},
     ...input.kind !== void 0 ? { kind: input.kind } : {},
     ...input.lane !== void 0 ? { lane: input.lane } : {},
-    ...input.submap !== void 0 ? { submap: input.submap } : {}
+    ...input.submap !== void 0 ? { submap: input.submap } : {},
+    ...input.spans !== void 0 ? { spans: input.spans } : {}
   };
   return ok({ ...map, nodes: [...map.nodes, node] });
 }
@@ -170,6 +199,14 @@ function linkNodes(map, from, to, label) {
   if (fromRank <= toRank) return err({ kind: "edge-not-downward", from, fromRank, to, toRank });
   return ok({ ...map, edges: [...map.edges, { from, to, ...label !== void 0 ? { label } : {} }] });
 }
+function stampSpans(node, status, at) {
+  if (status === void 0 || at === void 0) return node.spans;
+  const spans = node.spans ?? [];
+  const open = spans.findIndex((s) => s.to === void 0);
+  if (status === "in-progress") return open >= 0 ? node.spans : [...spans, { from: at }];
+  if (open < 0) return node.spans;
+  return spans.map((s, i) => i === open ? { from: s.from, to: Math.max(s.from, at) } : s);
+}
 function updateNode(map, input) {
   const node = findNode(map, input.id);
   if (!node) return err({ kind: "unknown-node", id: input.id });
@@ -180,7 +217,8 @@ function updateNode(map, input) {
   if (input.lane !== void 0 && input.lane !== null && !findLane(map, input.lane)) {
     return err({ kind: "unknown-lane", id: input.lane });
   }
-  const { group: currentGroup, kind: currentKind, lane: currentLane, submap: currentSubmap, ...bare } = node;
+  const { group: currentGroup, kind: currentKind, lane: currentLane, submap: currentSubmap, spans: _spans, ...bare } = node;
+  const nextSpans = stampSpans(node, input.status, input.at);
   const nextGroup = input.group === void 0 ? currentGroup : input.group === null ? void 0 : input.group;
   const nextKind = input.kind === void 0 ? currentKind : input.kind === null ? void 0 : input.kind;
   const nextLane = input.lane === void 0 ? currentLane : input.lane === null ? void 0 : input.lane;
@@ -191,6 +229,7 @@ function updateNode(map, input) {
     ...nextKind !== void 0 ? { kind: nextKind } : {},
     ...nextLane !== void 0 ? { lane: nextLane } : {},
     ...nextSubmap !== void 0 ? { submap: nextSubmap } : {},
+    ...nextSpans !== void 0 ? { spans: nextSpans } : {},
     ...input.status !== void 0 ? { status: input.status } : {},
     ...input.label !== void 0 ? { label: input.label } : {},
     ...input.evidence !== void 0 ? { evidence: input.evidence } : {},
@@ -250,6 +289,15 @@ function displayWidth(text) {
   let w = 0;
   for (const ch of text) w += charWidth(ch.codePointAt(0));
   return w;
+}
+function formatDuration(ms) {
+  const total = Math.max(0, Math.floor(ms / 1e3));
+  const [s, m, h, d] = [total % 60, Math.floor(total / 60) % 60, Math.floor(total / 3600) % 24, Math.floor(total / 86400)];
+  const pad = (n) => String(n).padStart(2, "0");
+  if (d > 0) return `${d}d${pad(h)}h`;
+  if (h > 0) return `${h}h${pad(m)}m`;
+  if (m > 0) return `${m}m${pad(s)}s`;
+  return `${s}s`;
 }
 function fitWidth(s, width) {
   if (displayWidth(s) <= width) return s;
@@ -928,6 +976,12 @@ function buildCanvasWith(map, opts, geo) {
       if (lx > LEFT_MARGIN) lx = canvas.text(lx, legendY, "   ", "none");
       lx = canvas.text(lx, legendY, `${glyphFor(status, legendOpts)} ${status}`, style);
     }
+    const elapsed = opts.now !== void 0 ? elapsedOf(map.nodes, opts.now) : 0;
+    if (elapsed > 0) {
+      const floor = isStalled(map.nodes, opts.now) ? "+" : "";
+      lx = canvas.text(lx, legendY, "   ", "none");
+      lx = canvas.text(lx, legendY, `~ ${formatDuration(elapsed)}${floor}`, "faint");
+    }
   }
   const hits = [...boxes.values()].map((b) => ({
     id: b.node.id,
@@ -1009,6 +1063,24 @@ function asArray(v) {
 }
 function optionalString(v) {
   return typeof v === "string" ? v : void 0;
+}
+function parseSpans(v) {
+  if (v === void 0) return void 0;
+  if (!Array.isArray(v)) return { ok: false, detail: "spans is not an array" };
+  const out = [];
+  for (const [i, raw] of v.entries()) {
+    if (!isRecord(raw)) return { ok: false, detail: `spans[${i}] is not an object` };
+    const from = raw["from"];
+    const to = raw["to"];
+    if (typeof from !== "number" || !Number.isFinite(from)) {
+      return { ok: false, detail: `spans[${i}] needs a finite numeric from` };
+    }
+    if (to !== void 0 && (typeof to !== "number" || !Number.isFinite(to))) {
+      return { ok: false, detail: `spans[${i}].to must be a finite number when present` };
+    }
+    out.push(to === void 0 ? { from } : { from, to });
+  }
+  return { ok: true, value: out };
 }
 function parseMap(raw, path) {
   if (!isRecord(raw)) return err({ kind: "bad-shape", path, detail: "root is not an object" });
@@ -1098,6 +1170,10 @@ function parseMap(raw, path) {
       if (!made.ok) return err({ kind: "invariant-violation", path, violation: made.error });
       submap = made.value;
     }
+    const spans = parseSpans(rawNode["spans"]);
+    if (spans !== void 0 && !spans.ok) {
+      return err({ kind: "bad-shape", path, detail: `nodes[${i}].${spans.detail}` });
+    }
     const declared = declareNode(map, {
       id: id.value,
       label,
@@ -1107,7 +1183,8 @@ function parseMap(raw, path) {
       ...group !== void 0 ? { group } : {},
       ...nodeKind !== void 0 ? { kind: nodeKind } : {},
       ...lane !== void 0 ? { lane } : {},
-      ...submap !== void 0 ? { submap } : {}
+      ...submap !== void 0 ? { submap } : {},
+      ...spans !== void 0 && spans.ok ? { spans: spans.value } : {}
     });
     if (!declared.ok) return err({ kind: "invariant-violation", path, violation: declared.error });
     map = declared.value;
@@ -1355,7 +1432,11 @@ function nearestHit(hits, cx, cy) {
   }
   return best;
 }
-function nodePanel(map, focusId, unicode, width, pinned, rows = PANEL_CONTENT_ROWS) {
+function nodePanel(map, focusId, unicode, width, pinned, rows = PANEL_CONTENT_ROWS, now) {
+  const clockOf = (nodes) => {
+    const ms = now === void 0 ? 0 : elapsedOf(nodes, now);
+    return ms > 0 ? [`~ ${formatDuration(ms)}${isStalled(nodes, now) ? "+" : ""}`] : [];
+  };
   const g = (s) => STATUS_GLYPH[s][unicode ? 0 : 1];
   const pinMark = pinned ? unicode ? "  \u2299 pinned" : "  * pinned" : "";
   const group = map.groups.find((gr) => gr.id === focusId);
@@ -1383,7 +1464,7 @@ function nodePanel(map, focusId, unicode, width, pinned, rows = PANEL_CONTENT_RO
     const lines2 = [
       {
         text: fitWidth(
-          `${g(status)} ${group.label} [${group.id}] \xB7 ${layerName2} \xB7 ${status} \xB7 ${members.length} member(s)${pinMark}`,
+          [`${g(status)} ${group.label} [${group.id}]`, layerName2, status, `${members.length} member(s)`].concat(clockOf(members)).join(" \xB7 ") + pinMark,
           width
         ),
         sgr: `${STATUS_SGR[status]};1`
@@ -1419,6 +1500,7 @@ function nodePanel(map, focusId, unicode, width, pinned, rows = PANEL_CONTENT_RO
     ...laneLabel !== void 0 ? [laneLabel] : [],
     ...node.kind !== void 0 ? [node.kind] : [],
     ...neutral ? [] : [node.status],
+    ...neutral ? [] : clockOf([node]),
     ...node.submap !== void 0 ? [`${unicode ? "\u229E" : "+"} ${node.submap}`] : []
   ];
   const [usesWord, usedByWord] = map.kind === "sequence" ? ["after", "before"] : ["uses", "used by"];
@@ -1442,19 +1524,23 @@ function nodePanel(map, focusId, unicode, width, pinned, rows = PANEL_CONTENT_RO
   }
   return lines.slice(0, rows);
 }
-function mapPanel(map, unicode, width, rows = PANEL_CONTENT_ROWS) {
+function mapPanel(map, unicode, width, rows = PANEL_CONTENT_ROWS, now) {
   const g = (s) => STATUS_GLYPH[s][unicode ? 0 : 1];
   const count = (s) => map.nodes.filter((n) => n.status === s).length;
   const statuses = ["done", "in-progress", "planned", "regressed"];
   const counts = statuses.filter((s) => count(s) > 0).map((s) => `${g(s)} ${count(s)} ${s}`).join("   ");
   const parts = [`${map.layers.length} layers`, `${map.nodes.length} nodes`, `${map.edges.length} edges`];
   if (map.lanes.length > 0) parts.push(`${map.lanes.length} lanes`);
+  const elapsed = now === void 0 ? 0 : elapsedOf(map.nodes, now);
+  const effort = now === void 0 ? 0 : effortOf(map.nodes, now);
+  const floor = elapsed > 0 && isStalled(map.nodes, now) ? "+" : "";
+  const timing = elapsed > 0 ? `~ ${formatDuration(elapsed)}${floor} elapsed \xB7 ${formatDuration(effort)}${floor} effort` + (effort > elapsed ? ` \xB7 ${(effort / elapsed).toFixed(1)}\xD7 parallel` : "") : "";
   const lines = [
     { text: fitWidth(map.title ?? "mellos map", width), sgr: "1" },
     { text: fitWidth(parts.join(" \xB7 "), width), sgr: "90" },
     // documentation kinds document structure, not progress
     { text: fitWidth(isNeutralKind(map) ? `${map.kind} diagram` : counts, width), sgr: isNeutralKind(map) ? "90" : "" },
-    { text: "", sgr: "" },
+    { text: fitWidth(timing, width), sgr: "90" },
     { text: "hover a node to inspect \xB7 click to pin", sgr: "90" }
   ];
   while (lines.length < rows) lines.push({ text: "", sgr: "" });
@@ -1544,13 +1630,14 @@ function main() {
     panelContentRows = clampPanelRows(panelContentRows, process.stdout.rows ?? 30, tabRows());
     const viewH = viewHeight();
     const focus = hoverId ?? selectedId;
+    const now = Date.now();
     let body;
     let panned = "";
     let pannable = false;
     if (map !== void 0) {
       const windowed = renderMapWindow(
         map,
-        { color: cfg.color, unicode: cfg.unicode, spinnerFrame, focus, zoom },
+        { color: cfg.color, unicode: cfg.unicode, spinnerFrame, focus, zoom, now },
         { x: offsetX, y: offsetY, width: cols, height: viewH }
       );
       const maxX = Math.max(0, windowed.contentWidth - cols);
@@ -1577,9 +1664,9 @@ function main() {
     if (map === void 0) {
       panel = Array.from({ length: panelContentRows }, () => ({ text: "", sgr: "" }));
     } else if (focus !== void 0) {
-      panel = nodePanel(map, focus, cfg.unicode, panelWidth, selectedId === focus, panelContentRows) ?? mapPanel(map, cfg.unicode, panelWidth, panelContentRows);
+      panel = nodePanel(map, focus, cfg.unicode, panelWidth, selectedId === focus, panelContentRows, now) ?? mapPanel(map, cfg.unicode, panelWidth, panelContentRows, now);
     } else {
-      panel = mapPanel(map, cfg.unicode, panelWidth, panelContentRows);
+      panel = mapPanel(map, cfg.unicode, panelWidth, panelContentRows, now);
     }
     const grip = cfg.unicode ? " \u22EF " : " ~ ";
     const bar = (cfg.unicode ? "\u2500" : "-").repeat(cols);

--- a/src/domain/ops.test.ts
+++ b/src/domain/ops.test.ts
@@ -23,6 +23,11 @@ import {
   removeNode,
   setKind,
   setTitle,
+  IDLE_CAP_MS,
+  effortOf,
+  elapsedOf,
+  isStalled,
+  spanTotal,
   updateNode,
 } from './ops.js';
 import {
@@ -30,8 +35,10 @@ import {
   type GroupId,
   type LaneId,
   type LayerId,
+  type MapNode,
   type MellosMap,
   type NodeId,
+  type WorkSpan,
   type NodeKind,
   type Result,
   type SubmapRef,
@@ -410,5 +417,108 @@ describe('operations are pure', () => {
 
   it('setTitle returns a retitled copy', () => {
     expect(setTitle(EMPTY_MAP, '梅勒斯地图').title).toBe('梅勒斯地图');
+  });
+});
+
+describe('work spans and elapsed time', () => {
+  const T = 1_700_000_000_000;
+  const s = (from: number, to?: number): WorkSpan => (to === undefined ? { from } : { from, to });
+  const findNode = (map: MellosMap, id: string): MapNode | undefined => map.nodes.find((n) => (n.id as string) === id);
+
+  it('measures a union, so overlapping stretches are counted once', () => {
+    expect(spanTotal([], T)).toBe(0);
+    expect(spanTotal([s(0, 10)], T)).toBe(10);
+    // disjoint: both count
+    expect(spanTotal([s(0, 10), s(20, 30)], T)).toBe(20);
+    // overlapping: the shared middle is counted once, not twice
+    expect(spanTotal([s(0, 10), s(5, 15)], T)).toBe(15);
+    // fully nested: the inner stretch adds nothing
+    expect(spanTotal([s(0, 100), s(10, 20)], T)).toBe(100);
+    // touching end to end merges seamlessly
+    expect(spanTotal([s(0, 10), s(10, 20)], T)).toBe(20);
+  });
+
+  it('is order-independent and survives a clock that ran backwards', () => {
+    expect(spanTotal([s(20, 30), s(0, 10), s(5, 25)], T)).toBe(30);
+    // to before from would be a negative stretch; it clamps to zero instead of refusing
+    expect(spanTotal([s(50, 40)], T)).toBe(0);
+  });
+
+  it('runs an open stretch up to now', () => {
+    expect(spanTotal([s(T - 5_000)], T)).toBe(5_000);
+    expect(spanTotal([s(T - 5_000), s(T - 3_000)], T)).toBe(5_000); // two open stretches still overlap
+  });
+
+  it('caps an open stretch at the idle limit, but never a closed one', () => {
+    const night = 14 * 3_600_000;
+    // abandoned spinner: bills the cap, not the night
+    expect(spanTotal([s(T - night)], T)).toBe(IDLE_CAP_MS);
+    // a genuinely long stretch that was closed has two real stamps — untouched
+    expect(spanTotal([s(T - night, T)], T)).toBe(night);
+    // the cap is a parameter, so a caller with different tolerance can say so
+    expect(spanTotal([s(T - night)], T, 60_000)).toBe(60_000);
+  });
+
+  it('reports when a total has become a floor rather than a measurement', () => {
+    const node = (spans: WorkSpan[]): MapNode => ({ id: nid('n'), label: 'N', layer: lid('base'), status: 'in-progress', spans });
+    expect(isStalled([node([s(T - IDLE_CAP_MS - 1)])], T)).toBe(true);
+    expect(isStalled([node([s(T - 1_000)])], T)).toBe(false); // open but young
+    expect(isStalled([node([s(T - 10 * 3_600_000, T)])], T)).toBe(false); // long but closed
+    expect(isStalled([node([])], T)).toBe(false);
+  });
+
+  it('opens a span on entering in-progress and closes it on leaving', () => {
+    let map = threeBands();
+    map = must(declareNode(map, { id: nid('core'), label: '核心', layer: lid('primitives') }));
+    expect(findNode(map, 'core')?.spans).toBeUndefined();
+
+    map = must(updateNode(map, { id: nid('core'), status: 'in-progress', at: T }));
+    expect(findNode(map, 'core')?.spans).toEqual([{ from: T }]);
+
+    // a second in-progress report keeps the one open stretch
+    map = must(updateNode(map, { id: nid('core'), status: 'in-progress', at: T + 1_000 }));
+    expect(findNode(map, 'core')?.spans).toEqual([{ from: T }]);
+
+    map = must(updateNode(map, { id: nid('core'), status: 'done', at: T + 60_000 }));
+    expect(findNode(map, 'core')?.spans).toEqual([{ from: T, to: T + 60_000 }]);
+    expect(elapsedOf([findNode(map, 'core')!], T + 999_999)).toBe(60_000);
+  });
+
+  it('gives rework its own stretch instead of overwriting the first', () => {
+    let map = threeBands();
+    map = must(declareNode(map, { id: nid('core'), label: '核心', layer: lid('primitives') }));
+    map = must(updateNode(map, { id: nid('core'), status: 'in-progress', at: T }));
+    map = must(updateNode(map, { id: nid('core'), status: 'done', at: T + 10_000 }));
+    map = must(updateNode(map, { id: nid('core'), status: 'regressed', at: T + 20_000 }));
+    map = must(updateNode(map, { id: nid('core'), status: 'in-progress', at: T + 30_000 }));
+    map = must(updateNode(map, { id: nid('core'), status: 'done', at: T + 45_000 }));
+    expect(findNode(map, 'core')?.spans).toEqual([
+      { from: T, to: T + 10_000 },
+      { from: T + 30_000, to: T + 45_000 },
+    ]);
+    expect(elapsedOf([findNode(map, 'core')!], T)).toBe(25_000); // 10s + 15s, the idle gap excluded
+  });
+
+  it('records nothing without a stamp, so relabels and store replays stay inert', () => {
+    let map = threeBands();
+    map = must(declareNode(map, { id: nid('core'), label: '核心', layer: lid('primitives') }));
+    map = must(updateNode(map, { id: nid('core'), status: 'in-progress' }));
+    expect(findNode(map, 'core')?.spans).toBeUndefined();
+    map = must(updateNode(map, { id: nid('core'), status: 'in-progress', at: T }));
+    map = must(updateNode(map, { id: nid('core'), label: '核心模块' }));
+    expect(findNode(map, 'core')?.spans).toEqual([{ from: T }]); // a relabel never closes a stretch
+  });
+
+  it('separates calendar time from effort, and their ratio is the parallelism', () => {
+    let map = threeBands();
+    map = must(declareNode(map, { id: nid('a'), label: 'A', layer: lid('primitives') }));
+    map = must(declareNode(map, { id: nid('b'), label: 'B', layer: lid('primitives') }));
+    // both worked on over the very same minute
+    for (const id of ['a', 'b']) {
+      map = must(updateNode(map, { id: nid(id), status: 'in-progress', at: T }));
+      map = must(updateNode(map, { id: nid(id), status: 'done', at: T + 60_000 }));
+    }
+    expect(elapsedOf(map.nodes, T)).toBe(60_000); // one minute of calendar
+    expect(effortOf(map.nodes, T)).toBe(120_000); // two minutes of attention
   });
 });

--- a/src/domain/ops.ts
+++ b/src/domain/ops.ts
@@ -27,6 +27,7 @@ import {
   type NodeStatus,
   type Result,
   type SubmapRef,
+  type WorkSpan,
   err,
   ok,
 } from './types.js';
@@ -173,6 +174,77 @@ export function mapStatus(map: MellosMap): NodeStatus {
   return aggregateStatus(map.nodes);
 }
 
+/**
+ * How long a single OPEN span is allowed to accrue. A node left spinning
+ * because a session ended would otherwise bill the whole night to the map, and
+ * `14h` on the dashboard is worse than useless — it drowns every honest number
+ * beside it. Closed spans are never capped: they carry two real stamps.
+ *
+ * The cap makes a capped total a FLOOR, not a measurement, so every surface
+ * that shows one marks it (a trailing `+`). Deliberately crude — better a
+ * plainly-labelled lower bound than a precise-looking lie.
+ */
+export const IDLE_CAP_MS = 30 * 60_000;
+
+/**
+ * Measure of the UNION of `spans` — the wall-clock time during which at least
+ * one of them was running. Overlap is counted ONCE, which is the whole point:
+ * two nodes worked on in parallel cost one stretch of calendar, not two.
+ *
+ * Open spans run up to `now` (this layer has no clock, so the caller supplies
+ * it) or `idleCap` past their start, whichever comes first. A total function:
+ * any order, any overlap, any nesting, and a `to` that precedes its `from` (a
+ * clock that went backwards) all yield a non-negative answer, never a refusal.
+ */
+export function spanTotal(spans: readonly WorkSpan[], now: number, idleCap: number = IDLE_CAP_MS): number {
+  const closed = spans
+    .map((s) => ({
+      from: s.from,
+      to: Math.max(s.from, s.to ?? Math.min(now, s.from + idleCap)),
+    }))
+    .sort((a, b) => a.from - b.from);
+  let total = 0;
+  let covered = -Infinity; // right edge of everything merged so far
+  for (const s of closed) {
+    const start = Math.max(s.from, covered);
+    if (s.to > start) total += s.to - start;
+    covered = Math.max(covered, s.to);
+  }
+  return total;
+}
+
+/**
+ * Derived, never stored: calendar time a set of nodes has cost. Parallel work
+ * collapses, so this is what a stopwatch on the wall would have read.
+ * One node, a group's members, a band, the whole map — same call.
+ */
+export function elapsedOf(nodes: readonly MapNode[], now: number, idleCap: number = IDLE_CAP_MS): number {
+  return spanTotal(
+    nodes.flatMap((n) => n.spans ?? []),
+    now,
+    idleCap,
+  );
+}
+
+/**
+ * Whether any of these nodes is still spinning past the idle cap — i.e. the
+ * duration beside it stopped being a measurement and became a lower bound.
+ * Surfaces use this to append `+`; nothing about the stored data changes.
+ */
+export function isStalled(nodes: readonly MapNode[], now: number, idleCap: number = IDLE_CAP_MS): boolean {
+  return nodes.some((n) => (n.spans ?? []).some((s) => s.to === undefined && now - s.from > idleCap));
+}
+
+/**
+ * Derived, never stored: attention spent — every node's own elapsed, added up.
+ * Exceeds elapsedOf by exactly the overlap, so effort / elapsed is the average
+ * number of nodes in flight. Report the two together or the pair reads as a
+ * bug; alone, either number misleads.
+ */
+export function effortOf(nodes: readonly MapNode[], now: number, idleCap: number = IDLE_CAP_MS): number {
+  return nodes.reduce((sum, n) => sum + elapsedOf([n], now, idleCap), 0);
+}
+
 export interface DeclareNodeInput {
   readonly id: NodeId;
   readonly label: string;
@@ -183,6 +255,8 @@ export interface DeclareNodeInput {
   readonly kind?: NodeKind;
   readonly lane?: LaneId;
   readonly submap?: SubmapRef;
+  /** Restored verbatim (the store replays a saved node); no clock is consulted. */
+  readonly spans?: readonly WorkSpan[];
 }
 
 /**
@@ -208,6 +282,7 @@ export function declareNode(map: MellosMap, input: DeclareNodeInput): Result<Mel
     ...(input.kind !== undefined ? { kind: input.kind } : {}),
     ...(input.lane !== undefined ? { lane: input.lane } : {}),
     ...(input.submap !== undefined ? { submap: input.submap } : {}),
+    ...(input.spans !== undefined ? { spans: input.spans } : {}),
   };
   return ok({ ...map, nodes: [...map.nodes, node] });
 }
@@ -247,12 +322,41 @@ export interface UpdateNodeInput {
   readonly lane?: LaneId | null;
   /** A SubmapRef links a child map page; null unlinks it. */
   readonly submap?: SubmapRef | null;
+  /**
+   * Wall-clock stamp (epoch ms) for this status change, supplied by the
+   * boundary — this layer owns no clock. Omit it and no timing is recorded,
+   * which is exactly what a pure relabel or a store replay wants.
+   */
+  readonly at?: number;
+}
+
+/**
+ * Span bookkeeping for one status change. Entering `in-progress` opens a
+ * stretch unless one is already open; leaving it closes the open one. Both are
+ * no-ops without a stamp, and a close never yields a backwards stretch.
+ *
+ * Note what is NOT here: no rejection of odd sequences. Two `in-progress`
+ * reports in a row keep the one stretch; a `done` with nothing open changes
+ * nothing. The ledger records, it does not police.
+ */
+function stampSpans(
+  node: MapNode,
+  status: NodeStatus | undefined,
+  at: number | undefined,
+): readonly WorkSpan[] | undefined {
+  if (status === undefined || at === undefined) return node.spans;
+  const spans = node.spans ?? [];
+  const open = spans.findIndex((s) => s.to === undefined);
+  if (status === 'in-progress') return open >= 0 ? node.spans : [...spans, { from: at }];
+  if (open < 0) return node.spans;
+  return spans.map((s, i) => (i === open ? { from: s.from, to: Math.max(s.from, at) } : s));
 }
 
 /**
  * Update a node's status, label, evidence, design detail, group membership,
  * kind and/or lane. Absent fields are left untouched. No transition rules:
  * the ledger records whatever the caller reports, whenever they report it.
+ * When `at` is supplied, a status change also opens or closes a work span.
  */
 export function updateNode(map: MellosMap, input: UpdateNodeInput): Result<MellosMap, MapError> {
   const node = findNode(map, input.id);
@@ -265,7 +369,8 @@ export function updateNode(map: MellosMap, input: UpdateNodeInput): Result<Mello
     return err({ kind: 'unknown-lane', id: input.lane });
   }
 
-  const { group: currentGroup, kind: currentKind, lane: currentLane, submap: currentSubmap, ...bare } = node;
+  const { group: currentGroup, kind: currentKind, lane: currentLane, submap: currentSubmap, spans: _spans, ...bare } = node;
+  const nextSpans = stampSpans(node, input.status, input.at);
   const nextGroup = input.group === undefined ? currentGroup : input.group === null ? undefined : input.group;
   const nextKind = input.kind === undefined ? currentKind : input.kind === null ? undefined : input.kind;
   const nextLane = input.lane === undefined ? currentLane : input.lane === null ? undefined : input.lane;
@@ -276,6 +381,7 @@ export function updateNode(map: MellosMap, input: UpdateNodeInput): Result<Mello
     ...(nextKind !== undefined ? { kind: nextKind } : {}),
     ...(nextLane !== undefined ? { lane: nextLane } : {}),
     ...(nextSubmap !== undefined ? { submap: nextSubmap } : {}),
+    ...(nextSpans !== undefined ? { spans: nextSpans } : {}),
     ...(input.status !== undefined ? { status: input.status } : {}),
     ...(input.label !== undefined ? { label: input.label } : {}),
     ...(input.evidence !== undefined ? { evidence: input.evidence } : {}),

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -136,6 +136,23 @@ export interface MapLane {
   readonly label: string;
 }
 
+/**
+ * One stretch of wall-clock time a node spent in progress, in epoch
+ * milliseconds. An absent `to` means the stretch is still open — the node is
+ * being worked on right now, and its length is only known relative to a `now`
+ * supplied from outside.
+ *
+ * Deliberately NOT an invariant: nothing here requires spans to be ordered,
+ * disjoint, or to hold at most one open stretch. Every consumer goes through
+ * spanTotal, which measures the UNION and is therefore total for any input —
+ * so a caller reporting overlapping stretches gets a defensible number instead
+ * of a refusal. The ledger records; it does not police (see module header).
+ */
+export interface WorkSpan {
+  readonly from: number;
+  readonly to?: number;
+}
+
 /** A unit of work living in exactly one band. */
 export interface MapNode {
   readonly id: NodeId;
@@ -154,6 +171,8 @@ export interface MapNode {
   readonly lane?: LaneId;
   /** Child map page: the pane badges the node ⊞ and double-click dives in. */
   readonly submap?: SubmapRef;
+  /** Stretches this node spent in progress. Absent = never started, or a map written before timing existed. */
+  readonly spans?: readonly WorkSpan[];
 }
 
 /** `from` USES `to`. Must point strictly downward (invariant I4). */

--- a/src/render/render.test.ts
+++ b/src/render/render.test.ts
@@ -21,7 +21,15 @@ import {
   type Result,
   type SubmapRef,
 } from '../domain/types.js';
-import { type ZoomStep, clampZoom, displayWidth, renderMap, renderMapWindow, zoomLabel } from './render.js';
+import {
+  type ZoomStep,
+  clampZoom,
+  displayWidth,
+  formatDuration,
+  renderMap,
+  renderMapWindow,
+  zoomLabel,
+} from './render.js';
 
 function must<T, E>(r: Result<T, E>): T {
   if (!r.ok) throw new Error(`expected ok, got error: ${JSON.stringify(r.error)}`);
@@ -392,5 +400,40 @@ describe('diagram kinds', () => {
     // -3 zoom truncates the label, but never the badge
     const tight = renderMap(map, { ...MONO, zoom: -3 }).join('\n');
     expect(tight).toContain('… ⊞');
+  });
+});
+
+describe('duration formatting and the legend clock', () => {
+  it('keeps a duration to two magnitudes', () => {
+    expect(formatDuration(0)).toBe('0s');
+    expect(formatDuration(900)).toBe('0s'); // sub-second rounds down, no invented precision
+    expect(formatDuration(42_000)).toBe('42s');
+    expect(formatDuration(252_000)).toBe('4m12s');
+    expect(formatDuration(7_500_000)).toBe('2h05m');
+    expect(formatDuration(273_600_000)).toBe('3d04h');
+    expect(formatDuration(-5_000)).toBe('0s'); // a backwards clock clamps
+  });
+
+  it('adds elapsed time to the legend only when a clock and spans are both present', () => {
+    const T = 1_700_000_000_000;
+    let map = must(declareLayer(EMPTY_MAP, { id: lid('base'), name: '原语层', rank: 0 }));
+    map = must(declareNode(map, { id: nid('core'), label: '核心', layer: lid('base') }));
+    map = must(updateNode(map, { id: nid('core'), status: 'in-progress', at: T }));
+    map = must(updateNode(map, { id: nid('core'), status: 'done', at: T + 252_000 }));
+
+    expect(renderMap(map, { ...MONO, now: T + 999_999 }).join('\n')).toContain('~ 4m12s');
+    // no clock supplied: the picture carries no timing at all
+    expect(renderMap(map, MONO).join('\n')).not.toContain('~ ');
+    // a clock but nothing ever worked on: still nothing to say
+    const untouched = must(declareNode(map, { id: nid('ghost'), label: '幽灵', layer: lid('base') }));
+    expect(renderMap({ ...untouched, nodes: [untouched.nodes[1]!] }, { ...MONO, now: T }).join('\n')).not.toContain('~ ');
+  });
+
+  it('marks a stalled legend total with a trailing plus', () => {
+    const T = 1_700_000_000_000;
+    let map = must(declareLayer(EMPTY_MAP, { id: lid('base'), name: '原语层', rank: 0 }));
+    map = must(declareNode(map, { id: nid('core'), label: '核心', layer: lid('base') }));
+    map = must(updateNode(map, { id: nid('core'), status: 'in-progress', at: T }));
+    expect(renderMap(map, { ...MONO, now: T + 14 * 3_600_000 }).join('\n')).toContain('~ 30m00s+');
   });
 });

--- a/src/render/render.ts
+++ b/src/render/render.ts
@@ -46,7 +46,7 @@
  * box spec (size, border, content) and the whitespace geometry change.
  */
 
-import { groupStatus } from '../domain/ops.js';
+import { elapsedOf, groupStatus, isStalled } from '../domain/ops.js';
 import type { DepEdge, MapNode, MellosMap, NodeId, NodeStatus } from '../domain/types.js';
 
 /** One wheel tick on the zoom ladder; see module header. */
@@ -92,6 +92,12 @@ export interface RenderOptions {
   readonly focus?: string | undefined;
   /** Position on the zoom ladder; omitted means ZOOM_DEFAULT (100%). */
   readonly zoom?: ZoomStep | undefined;
+  /**
+   * Wall clock (epoch ms) used to measure still-open work spans, so the legend
+   * can carry the map's elapsed time. Omitted means no timing is drawn — this
+   * module reads no clock of its own, exactly like spinnerFrame.
+   */
+  readonly now?: number | undefined;
 }
 
 /** A window over the rendered picture, in cell coordinates (0-based). */
@@ -131,6 +137,23 @@ export function displayWidth(text: string): number {
   let w = 0;
   for (const ch of text) w += charWidth(ch.codePointAt(0)!);
   return w;
+}
+
+/**
+ * A duration in milliseconds as a compact human string: `42s`, `4m12s`,
+ * `2h05m`, `3d04h`. Always two magnitudes at most, so it stays narrow enough
+ * to ride along in a panel header that is already crowded. Sub-second
+ * durations round down to `0s` rather than inventing precision nobody asked
+ * for; negatives (a clock that went backwards) clamp to zero.
+ */
+export function formatDuration(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const [s, m, h, d] = [total % 60, Math.floor(total / 60) % 60, Math.floor(total / 3600) % 24, Math.floor(total / 86400)];
+  const pad = (n: number): string => String(n).padStart(2, '0');
+  if (d > 0) return `${d}d${pad(h)}h`;
+  if (h > 0) return `${h}h${pad(m)}m`;
+  if (m > 0) return `${m}m${pad(s)}s`;
+  return `${s}s`;
 }
 
 /** Truncate to a display width, ANSI-free input, appending … when cut. */
@@ -1062,6 +1085,15 @@ function buildCanvasWith(map: MellosMap, opts: RenderOptions, geo: ZoomGeometry)
     for (const [status, style] of legendEntries) {
       if (lx > LEFT_MARGIN) lx = canvas.text(lx, legendY, '   ', 'none');
       lx = canvas.text(lx, legendY, `${glyphFor(status, legendOpts)} ${status}`, style);
+    }
+    // Calendar time the map has cost — parallel work counted once (elapsedOf).
+    // A trailing + means a node is still spinning past the idle cap, so the
+    // number is a floor rather than a measurement.
+    const elapsed = opts.now !== undefined ? elapsedOf(map.nodes, opts.now) : 0;
+    if (elapsed > 0) {
+      const floor = isStalled(map.nodes, opts.now!) ? '+' : '';
+      lx = canvas.text(lx, legendY, '   ', 'none');
+      lx = canvas.text(lx, legendY, `~ ${formatDuration(elapsed)}${floor}`, 'faint');
     }
   }
 

--- a/src/server/apply.test.ts
+++ b/src/server/apply.test.ts
@@ -8,7 +8,24 @@
 import { describe, expect, it } from 'vitest';
 
 import { EMPTY_MAP, type MellosMap, type Result } from '../domain/types.js';
-import { applyDeclare, applyRemove, applyUpdate, summarize } from './apply.js';
+import {
+  type DeclareInput,
+  type UpdateInput,
+  applyDeclare as applyDeclareAt,
+  applyRemove,
+  applyUpdate as applyUpdateAt,
+  summarize,
+} from './apply.js';
+
+/**
+ * Every apply* entry point takes the wall clock as an argument, so these specs
+ * pin it. Cases that care about elapsed time call the *At forms directly with
+ * their own stamps; everything else runs at T0 and never notices timing exists.
+ */
+const T0 = 1_700_000_000_000;
+const applyDeclare = (map: MellosMap, input: DeclareInput): Result<MellosMap, string> =>
+  applyDeclareAt(map, input, T0);
+const applyUpdate = (map: MellosMap, input: UpdateInput): Result<MellosMap, string> => applyUpdateAt(map, input, T0);
 
 function must<T, E>(r: Result<T, E>): T {
   if (!r.ok) throw new Error(`expected ok, got error: ${JSON.stringify(r.error)}`);

--- a/src/server/apply.ts
+++ b/src/server/apply.ts
@@ -102,8 +102,12 @@ export interface RemoveInput {
   readonly layers?: ReadonlyArray<string> | undefined;
 }
 
-/** Grow the map: title, kind, bands, lanes, groups, nodes, edges — in that order. */
-export function applyDeclare(map: MellosMap, input: DeclareInput): Result<MellosMap, string> {
+/**
+ * Grow the map: title, kind, bands, lanes, groups, nodes, edges — in that order.
+ * `at` is the wall-clock stamp for this batch (the domain owns no clock); a
+ * node declared straight into `in-progress` starts its first work span here.
+ */
+export function applyDeclare(map: MellosMap, input: DeclareInput, at: number): Result<MellosMap, string> {
   let next = input.title !== undefined ? setTitle(map, input.title) : map;
   if (input.kind !== undefined) {
     const kind = makeMapKind(input.kind);
@@ -182,6 +186,8 @@ export function applyDeclare(map: MellosMap, input: DeclareInput): Result<Mellos
       ...(kind !== undefined ? { kind } : {}),
       ...(lane !== undefined ? { lane } : {}),
       ...(submap !== undefined ? { submap } : {}),
+      // declared straight into work: the clock starts now
+      ...(status === 'in-progress' ? { spans: [{ from: at }] } : {}),
     });
     if (!declared.ok) return err(`nodes[${i}]: ${describeMapError(declared.error)}`);
     next = declared.value;
@@ -200,8 +206,12 @@ export function applyDeclare(map: MellosMap, input: DeclareInput): Result<Mellos
   return ok(next);
 }
 
-/** Record progress: status, label and evidence changes on existing nodes. */
-export function applyUpdate(map: MellosMap, input: UpdateInput): Result<MellosMap, string> {
+/**
+ * Record progress: status, label and evidence changes on existing nodes.
+ * `at` stamps every status change in the batch, so a node entering
+ * `in-progress` opens a work span and one leaving it closes that span.
+ */
+export function applyUpdate(map: MellosMap, input: UpdateInput, at: number): Result<MellosMap, string> {
   let next = map;
   for (const [i, u] of input.updates.entries()) {
     const id = makeNodeId(u.id);
@@ -242,6 +252,7 @@ export function applyUpdate(map: MellosMap, input: UpdateInput): Result<MellosMa
     }
     const updated = updateNode(next, {
       id: id.value,
+      at,
       ...(status !== undefined ? { status } : {}),
       ...(u.label !== undefined ? { label: u.label } : {}),
       ...(u.evidence !== undefined ? { evidence: u.evidence } : {}),

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -184,7 +184,7 @@ export function buildServer(stateFile: string): McpServer {
           .optional(),
       },
     },
-    (input) => mutate(input.page, (map) => applyDeclare(map, input)),
+    (input) => mutate(input.page, (map) => applyDeclare(map, input, Date.now())),
   );
 
   server.registerTool(
@@ -224,7 +224,7 @@ export function buildServer(stateFile: string): McpServer {
           .min(1),
       },
     },
-    (input) => mutate(input.page, (map) => applyUpdate(map, input)),
+    (input) => mutate(input.page, (map) => applyUpdate(map, input, Date.now())),
   );
 
   server.registerTool(
@@ -270,7 +270,9 @@ export function buildServer(stateFile: string): McpServer {
       const current = loadOrEmpty(fileOf(input.page));
       if (!current.ok) return text(current.error, true);
       const zoom = clampZoom(input.zoom ?? 0);
-      return text(renderMap(current.value, { color: false, unicode: true, spinnerFrame: 0, zoom }).join('\n'));
+      return text(
+        renderMap(current.value, { color: false, unicode: true, spinnerFrame: 0, zoom, now: Date.now() }).join('\n'),
+      );
     },
   );
 

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -256,3 +256,52 @@ describe('atomicity (P2)', () => {
     expect(readdirSync(dir)).toEqual(['map.json']);
   });
 });
+
+describe('work spans on disk', () => {
+  const T = 1_700_000_000_000;
+
+  function timedMap(): MellosMap {
+    let map = must(declareLayer(EMPTY_MAP, { id: 'base' as LayerId, name: '原语层', rank: 0 }));
+    map = must(declareNode(map, { id: 'core' as NodeId, label: '核心', layer: 'base' as LayerId }));
+    map = must(updateNode(map, { id: 'core' as NodeId, status: 'in-progress', at: T }));
+    map = must(updateNode(map, { id: 'core' as NodeId, status: 'done', at: T + 60_000 }));
+    map = must(updateNode(map, { id: 'core' as NodeId, status: 'in-progress', at: T + 90_000 }));
+    return map;
+  }
+
+  it('survives a serialize/parse round trip, open stretch included', () => {
+    const map = timedMap();
+    const back = must(parseMap(JSON.parse(serializeMap(map)), 'test'));
+    expect(back.nodes[0]!.spans).toEqual([{ from: T, to: T + 60_000 }, { from: T + 90_000 }]);
+    expect(back).toEqual(map);
+  });
+
+  it('stays on version 1, so an older reader still opens the file', () => {
+    expect(JSON.parse(serializeMap(timedMap())).version).toBe(1);
+  });
+
+  it('reads a map written before timing existed', () => {
+    const legacy = {
+      version: 1,
+      layers: [{ id: 'base', name: '原语层', rank: 0 }],
+      nodes: [{ id: 'core', label: '核心', layer: 'base', status: 'done' }],
+      edges: [],
+    };
+    expect(must(parseMap(legacy, 'test')).nodes[0]!.spans).toBeUndefined();
+  });
+
+  it('refuses malformed spans rather than silently dropping time', () => {
+    const withSpans = (spans: unknown): unknown => ({
+      version: 1,
+      layers: [{ id: 'base', name: '原语层', rank: 0 }],
+      nodes: [{ id: 'core', label: '核心', layer: 'base', status: 'done', spans }],
+      edges: [],
+    });
+    expect(mustFail(parseMap(withSpans('soon'), 'test')).kind).toBe('bad-shape');
+    expect(mustFail(parseMap(withSpans([{ to: 5 }]), 'test')).kind).toBe('bad-shape');
+    expect(mustFail(parseMap(withSpans([{ from: 'yesterday' }]), 'test')).kind).toBe('bad-shape');
+    expect(mustFail(parseMap(withSpans([{ from: 1, to: null }]), 'test')).kind).toBe('bad-shape');
+    // an open stretch is legal, not malformed
+    expect(parseMap(withSpans([{ from: 1 }]), 'test').ok).toBe(true);
+  });
+});

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -30,6 +30,7 @@ import {
   type MapError,
   type MellosMap,
   type Result,
+  type WorkSpan,
   describeMapError,
   err,
   makeGroupId,
@@ -124,6 +125,34 @@ function asArray(v: unknown): readonly unknown[] {
 
 function optionalString(v: unknown): string | undefined {
   return typeof v === 'string' ? v : undefined;
+}
+
+/**
+ * Read a node's work spans. Absent (the common case, and every map written
+ * before timing existed) yields undefined; anything present must be
+ * well-formed, because a silently-dropped span would understate a duration
+ * and no reader could tell. Ordering and overlap are NOT checked — spanTotal
+ * is total, and the domain deliberately holds no invariant there.
+ */
+function parseSpans(
+  v: unknown,
+): { ok: true; value: readonly WorkSpan[] } | { ok: false; detail: string } | undefined {
+  if (v === undefined) return undefined;
+  if (!Array.isArray(v)) return { ok: false, detail: 'spans is not an array' };
+  const out: WorkSpan[] = [];
+  for (const [i, raw] of v.entries()) {
+    if (!isRecord(raw)) return { ok: false, detail: `spans[${i}] is not an object` };
+    const from = raw['from'];
+    const to = raw['to'];
+    if (typeof from !== 'number' || !Number.isFinite(from)) {
+      return { ok: false, detail: `spans[${i}] needs a finite numeric from` };
+    }
+    if (to !== undefined && (typeof to !== 'number' || !Number.isFinite(to))) {
+      return { ok: false, detail: `spans[${i}].to must be a finite number when present` };
+    }
+    out.push(to === undefined ? { from } : { from, to });
+  }
+  return { ok: true, value: out };
 }
 
 /**
@@ -226,6 +255,10 @@ export function parseMap(raw: unknown, path: string): Result<MellosMap, StoreErr
       if (!made.ok) return err({ kind: 'invariant-violation', path, violation: made.error });
       submap = made.value;
     }
+    const spans = parseSpans(rawNode['spans']);
+    if (spans !== undefined && !spans.ok) {
+      return err({ kind: 'bad-shape', path, detail: `nodes[${i}].${spans.detail}` });
+    }
     const declared = declareNode(map, {
       id: id.value,
       label,
@@ -236,6 +269,7 @@ export function parseMap(raw: unknown, path: string): Result<MellosMap, StoreErr
       ...(nodeKind !== undefined ? { kind: nodeKind } : {}),
       ...(lane !== undefined ? { lane } : {}),
       ...(submap !== undefined ? { submap } : {}),
+      ...(spans !== undefined && spans.ok ? { spans: spans.value } : {}),
     });
     if (!declared.ok) return err({ kind: 'invariant-violation', path, violation: declared.error });
     map = declared.value;

--- a/src/watch/watch.test.ts
+++ b/src/watch/watch.test.ts
@@ -130,6 +130,73 @@ describe('mapPanel (dashboard)', () => {
   });
 });
 
+describe('timing in the panels', () => {
+  const T = 1_700_000_000_000;
+
+  function timed(): MellosMap {
+    let map = must(declareLayer(EMPTY_MAP, { id: lid('base'), name: '原语层', rank: 0 }));
+    map = must(declareGroup(map, { id: gid('kernel'), label: '内核', layer: lid('base') }));
+    map = must(declareNode(map, { id: nid('a'), label: 'A', layer: lid('base'), group: gid('kernel') }));
+    map = must(declareNode(map, { id: nid('b'), label: 'B', layer: lid('base'), group: gid('kernel') }));
+    // A and B are worked on over the same minute, so they cost one minute of calendar
+    for (const id of ['a', 'b']) {
+      map = must(updateNode(map, { id: nid(id), status: 'in-progress', at: T }));
+      map = must(updateNode(map, { id: nid(id), status: 'done', at: T + 60_000 }));
+    }
+    return map;
+  }
+
+  it("puts a node's own elapsed time in its header", () => {
+    const panel = nodePanel(timed(), 'a', true, 200, false, 6, T + 999_999)!;
+    expect(panel[0]!.text).toContain('~ 1m00s');
+  });
+
+  it('leaves the header alone for a node nobody has started', () => {
+    const map = must(declareNode(timed(), { id: nid('ghost'), label: '幽灵', layer: lid('base') }));
+    expect(nodePanel(map, 'ghost', true, 200, false, 6, T + 999_999)![0]!.text).not.toContain('~ ');
+    // and with no clock at all, even a worked node stays silent
+    expect(nodePanel(map, 'a', true, 200, false, 6)![0]!.text).not.toContain('~ ');
+  });
+
+  it('collapses parallel members into one stretch on a group header', () => {
+    const panel = nodePanel(timed(), 'kernel', true, 200, false, 6, T + 999_999)!;
+    expect(panel[0]!.text).toContain('~ 1m00s'); // not 2m00s — the two ran together
+  });
+
+  it('shows calendar time beside effort, and the parallelism between them', () => {
+    const line = mapPanel(timed(), true, 200, 6, T + 999_999)[3]!.text;
+    expect(line).toContain('1m00s elapsed');
+    expect(line).toContain('2m00s effort');
+    expect(line).toContain('2.0× parallel');
+  });
+
+  it('stops an abandoned spinner from billing the whole night, and says so', () => {
+    let map = must(declareLayer(EMPTY_MAP, { id: lid('base'), name: '原语层', rank: 0 }));
+    map = must(declareNode(map, { id: nid('left-running'), label: '忘了收工', layer: lid('base') }));
+    map = must(updateNode(map, { id: nid('left-running'), status: 'in-progress', at: T }));
+
+    const overnight = T + 14 * 3_600_000;
+    const header = nodePanel(map, 'left-running', true, 200, false, 6, overnight)![0]!.text;
+    expect(header).toContain('~ 30m00s+'); // capped, and marked as a floor
+    expect(header).not.toContain('14h');
+
+    // under the cap it is an ordinary measurement, no plus sign
+    const early = nodePanel(map, 'left-running', true, 200, false, 6, T + 300_000)![0]!.text;
+    expect(early).toContain('~ 5m00s');
+    expect(early).not.toContain('+');
+  });
+
+  it('drops the parallel factor when nothing actually overlapped', () => {
+    let map = must(declareLayer(EMPTY_MAP, { id: lid('base'), name: '原语层', rank: 0 }));
+    map = must(declareNode(map, { id: nid('solo'), label: '独', layer: lid('base') }));
+    map = must(updateNode(map, { id: nid('solo'), status: 'in-progress', at: T }));
+    map = must(updateNode(map, { id: nid('solo'), status: 'done', at: T + 30_000 }));
+    const line = mapPanel(map, true, 200, 6, T + 999_999)[3]!.text;
+    expect(line).toContain('30s elapsed');
+    expect(line).not.toContain('parallel'); // 1.0× is noise, not information
+  });
+});
+
 describe('pageTabRow', () => {
   const tabs: PageTab[] = [
     { title: '开发回放', status: 'done', active: true, fresh: false },

--- a/src/watch/watch.ts
+++ b/src/watch/watch.ts
@@ -37,7 +37,7 @@ import { realpathSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-import { groupStatus, mapStatus } from '../domain/ops.js';
+import { effortOf, elapsedOf, groupStatus, isStalled, mapStatus } from '../domain/ops.js';
 import { type MellosMap, type NodeStatus } from '../domain/types.js';
 import {
   type BoxHit,
@@ -46,6 +46,7 @@ import {
   clampZoom,
   displayWidth,
   fitWidth,
+  formatDuration,
   isNeutralKind,
   kindGlyph,
   renderMapWindow,
@@ -304,7 +305,17 @@ export function nodePanel(
   width: number,
   pinned: boolean,
   rows: number = PANEL_CONTENT_ROWS,
+  now?: number,
 ): PanelLine[] | undefined {
+  /**
+   * `~ 4m12s` for anything that has been worked on; nothing at all for the
+   * untouched (a bare `0s` would suggest it had been measured). A trailing `+`
+   * marks a total the idle cap turned into a floor.
+   */
+  const clockOf = (nodes: readonly MellosMap['nodes'][number][]): string[] => {
+    const ms = now === undefined ? 0 : elapsedOf(nodes, now);
+    return ms > 0 ? [`~ ${formatDuration(ms)}${isStalled(nodes, now!) ? '+' : ''}`] : [];
+  };
   const g = (s: NodeStatus): string => STATUS_GLYPH[s][unicode ? 0 : 1];
   const pinMark = pinned ? (unicode ? '  ⊙ pinned' : '  * pinned') : '';
 
@@ -338,7 +349,9 @@ export function nodePanel(
     const lines: PanelLine[] = [
       {
         text: fitWidth(
-          `${g(status)} ${group.label} [${group.id}] · ${layerName} · ${status} · ${members.length} member(s)${pinMark}`,
+          [`${g(status)} ${group.label} [${group.id}]`, layerName, status, `${members.length} member(s)`]
+            .concat(clockOf(members))
+            .join(' · ') + pinMark,
           width,
         ),
         sgr: `${STATUS_SGR[status]};1`,
@@ -382,6 +395,7 @@ export function nodePanel(
     ...(laneLabel !== undefined ? [laneLabel] : []),
     ...(node.kind !== undefined ? [node.kind as string] : []),
     ...(neutral ? [] : [node.status]),
+    ...(neutral ? [] : clockOf([node])),
     ...(node.submap !== undefined ? [`${unicode ? '⊞' : '+'} ${node.submap}`] : []),
   ];
   // On sequence pages an edge is a moment in time, not a dependency:
@@ -414,6 +428,7 @@ export function mapPanel(
   unicode: boolean,
   width: number,
   rows: number = PANEL_CONTENT_ROWS,
+  now?: number,
 ): PanelLine[] {
   const g = (s: NodeStatus): string => STATUS_GLYPH[s][unicode ? 0 : 1];
   const count = (s: NodeStatus): number => map.nodes.filter((n) => n.status === s).length;
@@ -424,12 +439,27 @@ export function mapPanel(
     .join('   ');
   const parts = [`${map.layers.length} layers`, `${map.nodes.length} nodes`, `${map.edges.length} edges`];
   if (map.lanes.length > 0) parts.push(`${map.lanes.length} lanes`);
+  // Elapsed is calendar time (parallel work counted once); effort is the sum of
+  // the nodes' own times. Never show one without the other: alone, elapsed hides
+  // how much was going on and effort reads as a wall clock that lost its mind.
+  // Their ratio is what the pair is really for — how many nodes ran at a time.
+  // A trailing + on both: a node still spinning past the idle cap has stopped
+  // accruing, so each number is a floor rather than a measurement.
+  const elapsed = now === undefined ? 0 : elapsedOf(map.nodes, now);
+  const effort = now === undefined ? 0 : effortOf(map.nodes, now);
+  const floor = elapsed > 0 && isStalled(map.nodes, now!) ? '+' : '';
+  const timing =
+    elapsed > 0
+      ? `~ ${formatDuration(elapsed)}${floor} elapsed · ${formatDuration(effort)}${floor} effort` +
+        (effort > elapsed ? ` · ${(effort / elapsed).toFixed(1)}× parallel` : '')
+      : '';
+
   const lines: PanelLine[] = [
     { text: fitWidth(map.title ?? 'mellos map', width), sgr: '1' },
     { text: fitWidth(parts.join(' · '), width), sgr: '90' },
     // documentation kinds document structure, not progress
     { text: fitWidth(isNeutralKind(map) ? `${map.kind} diagram` : counts, width), sgr: isNeutralKind(map) ? '90' : '' },
-    { text: '', sgr: '' },
+    { text: fitWidth(timing, width), sgr: '90' },
     { text: 'hover a node to inspect · click to pin', sgr: '90' },
   ];
   while (lines.length < rows) lines.push({ text: '', sgr: '' });
@@ -551,6 +581,9 @@ function main(): void {
     panelContentRows = clampPanelRows(panelContentRows, process.stdout.rows ?? 30, tabRows());
     const viewH = viewHeight();
     const focus = hoverId ?? selectedId;
+    // One clock read per frame: the panels and the picture must not disagree
+    // about how long an open span has been running.
+    const now = Date.now();
 
     let body: string[];
     let panned = '';
@@ -558,7 +591,7 @@ function main(): void {
     if (map !== undefined) {
       const windowed = renderMapWindow(
         map,
-        { color: cfg.color, unicode: cfg.unicode, spinnerFrame, focus, zoom },
+        { color: cfg.color, unicode: cfg.unicode, spinnerFrame, focus, zoom, now },
         { x: offsetX, y: offsetY, width: cols, height: viewH },
       );
       // clamp AFTER measuring so a shrinking map pulls the view back in
@@ -589,10 +622,10 @@ function main(): void {
       panel = Array.from({ length: panelContentRows }, () => ({ text: '', sgr: '' }));
     } else if (focus !== undefined) {
       panel =
-        nodePanel(map, focus, cfg.unicode, panelWidth, selectedId === focus, panelContentRows) ??
-        mapPanel(map, cfg.unicode, panelWidth, panelContentRows);
+        nodePanel(map, focus, cfg.unicode, panelWidth, selectedId === focus, panelContentRows, now) ??
+        mapPanel(map, cfg.unicode, panelWidth, panelContentRows, now);
     } else {
-      panel = mapPanel(map, cfg.unicode, panelWidth, panelContentRows);
+      panel = mapPanel(map, cfg.unicode, panelWidth, panelContentRows, now);
     }
     // the separator doubles as the drag handle — mark its grip in the middle
     const grip = cfg.unicode ? ' ⋯ ' : ' ~ ';


### PR DESCRIPTION
The map has always said *what* was built and in what order. It never said **how long** any of it took. Nodes now carry work spans, and every surface can report them.

```
~ 4m19s elapsed · 7m20s effort · 1.70× parallel
■ 解析器 [parser] · 基础 · done · ~ 3m01s
⠿ 忘了收工 [b]   · 基础 · in-progress · ~ 30m00s+
· 未动工的节点  · 基础 · planned
```

## How it works

A status change stamped with `at` opens or closes a span on the node. Entering `in-progress` opens one; leaving it closes it; rework gets its **own** stretch instead of overwriting the first, so a `done → regressed → in-progress → done` cycle records both attempts and excludes the idle gap between them.

Durations then come from **one function**:

```
spanTotal(spans, now) = the measure of the UNION of those spans
```

Overlap is counted once — two nodes worked on in parallel cost one stretch of calendar, not two. `elapsedOf` feeds it a node set (one node, a group's members, a band, the whole map — same call), and `effortOf` sums the per-node figures.

That reduction is what makes the feature small: there is no separate "group duration" or "map duration" logic, and because the difference between the two numbers **is** the overlap, their ratio is the average parallelism for free.

## Advantages

- **One algorithm, four scopes.** Node, group, layer and map totals are the same call with a different node set. A single node's spans never overlap, so the union degenerates to a sum — no special case needed.
- **Rework is visible.** Two stamps per attempt means a node that broke and was fixed shows both stretches and excludes the gap. A `startedAt`/`finishedAt` pair would have silently overwritten the first attempt.
- **The domain keeps its "no clock" contract.** `types.ts` and `render.ts` both declare they hold no I/O and no clock. `at` and `now` are parameters, exactly like the existing `spinnerFrame`, so everything stays a pure function of its inputs and every test pins the clock instead of mocking one.
- **Backward and forward compatible.** Spans ride along in the existing `nodes` array and the file stays at `version: 1`. An older reader ignores the unknown field; a map written before timing loads unchanged.
- **Elapsed and effort are never shown alone.** Apart, each misleads — elapsed hides how much was going on, effort reads as a wall clock that lost its mind. Together with their ratio they answer "how long, and how wide."

## Problems and the trade-offs taken

**An abandoned spinner would bill the whole night.** A node left `in-progress` when a session ends keeps accruing against `now`, and `14h` on the dashboard drowns every honest number beside it.
*Taken:* an open span accrues at most `IDLE_CAP_MS` (30 min). Closed spans are never capped — they carry two real stamps, so a genuinely long finished stretch stays intact.
*Cost:* a node genuinely worked on for over 30 minutes is under-reported. Judged the lesser evil: under-reporting one running node beats letting one forgotten node swamp the map. A capped total is a **floor**, so every surface marks it with a trailing `+` — showing a bare `30m00s` would be a precise-looking lie. The threshold is a constant today, but `spanTotal` / `elapsedOf` / `isStalled` all take `idleCap` as a parameter, so a `--idle-cap` flag is a small follow-up.

**Sum ≠ union, and that reads as a bug.** Someone seeing `4m19s` and `7m20s` on the same line will assume one of them is wrong.
*Taken:* both are always shown, each labelled, with the ratio that explains the gap. The `1.0×` case is suppressed — with no overlap it is noise, not information.

**No invariant on spans.** Nothing rejects unordered, overlapping, or multiple-open spans.
*Taken:* deliberate. `spanTotal` measures a union, so it is **total** — any order, any overlap, any nesting, and even a `to` that precedes its `from` (a clock that ran backwards) yield a non-negative answer. An invariant would buy no correctness and only add a refusal path, and this repo's stated rule is that the ledger records rather than polices. "At most one open span" is maintained by the bookkeeping, not enforced.

**Wall clock, not work clock.** The timer cannot tell "actively working" from "the human went to lunch with a node marked in-progress."
*Taken:* accepted. Distinguishing them needs signals this process does not have. The idle cap bounds the damage; the README's own position is that an unflattering map is doing its job.

**Malformed spans on disk.** A dropped span silently understates a duration and no reader could tell.
*Taken:* `parseMap` refuses them as `bad-shape`. An absent `spans` is fine (that's every pre-existing map); a present but broken one is an error. An open span — `{ from }` with no `to` — is legal, not malformed.

**One version-1 caveat worth knowing:** if an *older* plugin build writes the file, it parses the map without spans and serializes them away. Round-tripping through an old version loses timing. That is the price of not bumping the version, and it seemed better than forcing a migration on every existing map.

## Tests

`npm run verify` green — typecheck clean, **174 passed**, build OK. 26 new cases:

- union: disjoint / overlapping / nested / end-to-end-touching / unordered / backwards clock / open spans
- the idle cap: open span capped, closed span untouched, cap as a parameter, `isStalled` across four shapes
- bookkeeping: open and close, repeated `in-progress` keeping one stretch, rework producing two, no stamp meaning no record (so a relabel and a store replay stay inert)
- disk: round trip with an open span, `version` still 1, a pre-timing map, four malformed shapes refused
- panels: node header, group header collapsing parallel members, elapsed/effort/ratio, the `+` marker, and both silent cases (no clock, never started)
- `formatDuration`: four magnitudes plus the negative clamp

## Note on scope

This is independent of #1 (the standby splash) and branches from `master`, so the two can be reviewed and merged in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)