### PR TITLE
Library surface + host-neutral .mellos store (0.19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,7 @@ node_modules/
 # note: dist/ is intentionally COMMITTED.
 # Claude Code installs plugins by cloning this repo without running any
 # build step, so the bundled MCP server and watcher must ship in-tree.
+# lib/ is NOT: only npm/library consumers need it, and they get it from a
+# pack (files includes lib) or a local `npm run build`.
+lib/
 *.tgz

--- a/README.md
+++ b/README.md
@@ -299,13 +299,26 @@ The repo is itself layered bottom-up, and each layer has its spec:
 | Layer | Code | Owns |
 | --- | --- | --- |
 | 0 domain | `src/domain/` | the map value, structural invariants, pure ops |
-| 1 store | `src/store/` | atomic state-file persistence, boundary validation |
+| 1 format | `src/store/format.ts` | the state-file format: replay-validated parse, serialize — I/O-free |
+| 1 store | `src/store/store.ts` | atomic state-file persistence on Node |
+| 1 semantics | `src/semantics/` | medium-neutral view semantics: zoom ladder, group aggregation, sequence flip |
 | 2 apply | `src/server/apply.ts` | tool inputs → transactional op sequences |
 | 3 server | `src/server/server.ts` | the four MCP tools over stdio |
 | 4 render | `src/render/`, `src/watch/` | ASCII renderer and the polling pane |
 
 `dist/` is committed deliberately: plugin installation clones this repo and
 runs nothing, so entry points ship bundled.
+
+### Library
+
+The lower layers are also a library (`npm run build` emits `lib/` with type
+declarations; npm packs it). Subpath exports mirror the source:
+`mellos-mapping/domain/types`, `/domain/ops`, `/format`, `/semantics` are
+**browser-safe** — no Node builtins in their import closure, gated by a test —
+so a graphical client (a web panel, an editor view) can parse state files and
+reuse the exact aggregation and zoom semantics the terminal pane draws with.
+`/store` (Node filesystem persistence) and `/render` (the terminal renderer)
+complete the surface for Node hosts.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ npx -y mellos-mapping
 ```
 
 The map file lands in the client session's working directory
-(`.claude/mellos-mapping.json`). Open the live pane from the same project:
+(`.mellos/map.json`). Open the live pane from the same project:
 
 ```
 npx -y -p mellos-mapping mellos-mapping-watch
@@ -224,8 +224,8 @@ its own pan, zoom and pinned node. Because every page is its own file, two
 Claude sessions writing two pages can never clobber each other — this is
 also the answer to running several Claude sessions in one project.
 
-State lives in `.claude/mellos-mapping.json` (the default page) plus
-`.claude/mellos-mapping.pages/<page>.json` for named pages — plain JSON,
+State lives in `.mellos/map.json` (the default page) plus
+`.mellos/pages/<page>.json` for named pages — plain JSON,
 safe to commit if you want the maps' history in git.
 
 ### Diagram kinds

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -134,7 +134,7 @@ CLI……）都能用标准 stdio 条目接入：
 npx -y mellos-mapping
 ```
 
-地图文件落在客户端会话的工作目录（`.claude/mellos-mapping.json`）。在同
+地图文件落在客户端会话的工作目录（`.mellos/map.json`）。在同
 一项目里打开实况面板：
 
 ```
@@ -204,8 +204,8 @@ npx -y -p mellos-mapping mellos-mapping-watch
 每页就是一个独立文件，两个 Claude 会话各写各页永远不会互相覆盖——这也是
 同一项目里跑多个 Claude 会话的正确姿势。
 
-地图状态存在 `.claude/mellos-mapping.json`（默认页）和
-`.claude/mellos-mapping.pages/<页名>.json`（命名页）——纯 JSON，想在 git
+地图状态存在 `.mellos/map.json`（默认页）和
+`.mellos/pages/<页名>.json`（命名页）——纯 JSON，想在 git
 里留下地图的历史就把它们提交进去。
 
 ### 图种

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -272,13 +272,25 @@ npm run verify   # 类型检查 + 测试 + 打包
 | 层 | 代码 | 职责 |
 | --- | --- | --- |
 | 0 domain | `src/domain/` | 地图值、结构不变量、纯操作 |
-| 1 store | `src/store/` | 原子化状态文件持久化、边界校验 |
+| 1 format | `src/store/format.ts` | 状态文件格式：重放校验的解析与序列化，零 I/O |
+| 1 store | `src/store/store.ts` | Node 上的原子化状态文件持久化 |
+| 1 semantics | `src/semantics/` | 媒介无关的视图语义：缩放阶梯、分组聚合、时序翻转 |
 | 2 apply | `src/server/apply.ts` | 工具输入 → 事务性操作序列 |
 | 3 server | `src/server/server.ts` | stdio 上的四个 MCP 工具 |
 | 4 render | `src/render/`、`src/watch/` | ASCII 渲染器和轮询面板 |
 
 `dist/` 是刻意提交的：插件安装就是克隆本仓库、不运行任何东西，所以入口
 文件以打包形式随仓库分发。
+
+### 库
+
+底部各层同时是一个库（`npm run build` 产出带类型声明的 `lib/`，npm 打包
+收录）。子路径导出与源码结构一一对应：`mellos-mapping/domain/types`、
+`/domain/ops`、`/format`、`/semantics` 是**浏览器安全**的——import 闭包中
+没有任何 Node 内建模块，由测试门禁守护——图形客户端（web 面板、编辑器
+视图）可以直接解析状态文件，并复用与终端面板完全一致的聚合与缩放语义。
+`/store`（Node 文件系统持久化）与 `/render`（终端渲染器）补齐 Node 宿主
+所需的完整表面。
 
 ## 许可证
 

--- a/commands/mmap.md
+++ b/commands/mmap.md
@@ -15,11 +15,11 @@ confirm what was saved and where. Then stop.
 
 Otherwise: open the live Mellos map watcher for this project in a separate terminal pane.
 The watcher is at `${CLAUDE_PLUGIN_ROOT}/dist/watch.mjs`. The store is
-MULTI-PAGE: the default page lives at `.claude/mellos-mapping.json` and named
-pages at `.claude/mellos-mapping.pages/<slug>.json` — the watcher takes the
+MULTI-PAGE: the default page lives at `.mellos/map.json` and named
+pages at `.mellos/pages/<slug>.json` — the watcher takes the
 default path as its base, polls ALL of these files, and redraws on change.
 The default file is optional; a project whose work lives on named pages has
-no `.claude/mellos-mapping.json` at all. So never probe that single file to
+no `.mellos/map.json` at all. So never probe that single file to
 decide whether a map exists — call `mmap_view`, which reads the real store.
 
 Follow the platform-appropriate route:
@@ -61,11 +61,11 @@ Follow the platform-appropriate route:
    running (default is to skip).
 
 2. **tmux session**: run
-   `tmux split-window -h -l 42% node "${CLAUDE_PLUGIN_ROOT}/dist/watch.mjs" --file "<PROJECT_DIR>/.claude/mellos-mapping.json" --page <PAGE_SLUG>`
+   `tmux split-window -h -l 42% node "${CLAUDE_PLUGIN_ROOT}/dist/watch.mjs" --file "<PROJECT_DIR>/.mellos/map.json" --page <PAGE_SLUG>`
    (same `--page` judgment as route 1; omit it when no page is the subject).
 
 3. **Neither**: print the command
-   `node "${CLAUDE_PLUGIN_ROOT}/dist/watch.mjs" --file "<PROJECT_DIR>/.claude/mellos-mapping.json" --page <PAGE_SLUG>`
+   `node "${CLAUDE_PLUGIN_ROOT}/dist/watch.mjs" --file "<PROJECT_DIR>/.mellos/map.json" --page <PAGE_SLUG>`
    and tell the user to run it in any second terminal themselves (add
    `--ascii` if their font lacks box-drawing characters).
 

--- a/dist/server.mjs
+++ b/dist/server.mjs
@@ -22303,10 +22303,81 @@ function serializeMap(map) {
 }
 
 // src/store/store.ts
-var STATE_FILE_RELATIVE_PATH = join(".claude", "mellos-mapping.json");
-var PAGES_DIR_NAME = "mellos-mapping.pages";
+var STATE_FILE_RELATIVE_PATH = join(".mellos", "map.json");
+var PAGES_DIR_NAME = "pages";
 function pageFilePath(defaultFile, page) {
   return page === void 0 ? defaultFile : join(dirname(defaultFile), PAGES_DIR_NAME, `${page}.json`);
+}
+var CONFIG_FILE_NAME = "config.json";
+var CONFIG_FILE_VERSION = 1;
+function configFilePath(defaultFile) {
+  return join(dirname(defaultFile), CONFIG_FILE_NAME);
+}
+var MAPPING_POLICIES = ["always", "complex", "on-request"];
+function makeMappingPolicy(raw) {
+  return MAPPING_POLICIES.includes(raw) ? ok(raw) : err({ kind: "invalid-policy", raw, allowed: MAPPING_POLICIES });
+}
+function describeMappingPolicy(policy) {
+  switch (policy) {
+    case "always":
+      return "map every structured task \u2014 workflows, designs, architecture, technical dependencies";
+    case "complex":
+      return "map only medium or complex tasks \u2014 several modules, a new subsystem, roughly an hour or more";
+    case "on-request":
+      return "map only when the user explicitly asks";
+  }
+}
+function isRecord2(v) {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+function loadMappingPolicy(defaultFile) {
+  const path = configFilePath(defaultFile);
+  let text2;
+  try {
+    text2 = readFileSync(path, "utf8");
+  } catch (e) {
+    if (e.code === "ENOENT") return ok(void 0);
+    throw e;
+  }
+  let raw;
+  try {
+    raw = JSON.parse(text2);
+  } catch (e) {
+    return err({ kind: "malformed-json", path, detail: e.message });
+  }
+  if (!isRecord2(raw)) return err({ kind: "bad-shape", path, detail: "root is not an object" });
+  if (raw["version"] !== CONFIG_FILE_VERSION) {
+    return err({ kind: "bad-shape", path, detail: `version is ${String(raw["version"])}, expected ${CONFIG_FILE_VERSION}` });
+  }
+  const rawPolicy = raw["policy"];
+  if (rawPolicy === void 0) return ok(void 0);
+  if (typeof rawPolicy !== "string") return err({ kind: "bad-shape", path, detail: "policy is not a string" });
+  const policy = makeMappingPolicy(rawPolicy);
+  return policy.ok ? ok(policy.value) : err({ kind: "bad-shape", path, detail: `policy is "${rawPolicy}", expected one of: ${MAPPING_POLICIES.join(" | ")}` });
+}
+function saveMappingPolicy(defaultFile, policy) {
+  const path = configFilePath(defaultFile);
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = path + ".tmp";
+  writeFileSync(tmp, JSON.stringify({ version: CONFIG_FILE_VERSION, policy }, null, 2) + "\n", "utf8");
+  renameSync(tmp, path);
+}
+var LEGACY_STATE_FILE_RELATIVE_PATH = join(".claude", "mellos-mapping.json");
+var LEGACY_PAGES_DIR_NAME = "mellos-mapping.pages";
+var LEGACY_CONFIG_FILE_NAME = "mellos-mapping.config.json";
+function migrateLegacyStore(defaultFile) {
+  const projectRoot = dirname(dirname(defaultFile));
+  const legacyDefault = join(projectRoot, LEGACY_STATE_FILE_RELATIVE_PATH);
+  const legacyPages = join(dirname(legacyDefault), LEGACY_PAGES_DIR_NAME);
+  const legacyConfig = join(dirname(legacyDefault), LEGACY_CONFIG_FILE_NAME);
+  const hasLegacy = existsSync(legacyDefault) || existsSync(legacyPages) || existsSync(legacyConfig);
+  const hasCurrent = existsSync(defaultFile) || existsSync(join(dirname(defaultFile), PAGES_DIR_NAME)) || existsSync(configFilePath(defaultFile));
+  if (!hasLegacy || hasCurrent) return false;
+  mkdirSync(dirname(defaultFile), { recursive: true });
+  if (existsSync(legacyDefault)) renameSync(legacyDefault, defaultFile);
+  if (existsSync(legacyPages)) renameSync(legacyPages, join(dirname(defaultFile), PAGES_DIR_NAME));
+  if (existsSync(legacyConfig)) renameSync(legacyConfig, configFilePath(defaultFile));
+  return true;
 }
 function loadMapFile(path) {
   let text2;
@@ -22528,7 +22599,7 @@ function summarize(map) {
 
 // src/server/server.ts
 var SERVER_NAME = "mellos-mapping";
-var SERVER_VERSION = "0.18.0";
+var SERVER_VERSION = "0.19.0";
 var ID = external_exports.string().regex(/^[a-z0-9][a-z0-9-]{0,63}$/, "lowercase letters, digits and dashes, 1-64 chars").describe("stable kebab-case identifier");
 var PAGE = ID.optional().describe(
   "page (parallel map) this call targets; omit for the default page. One effort = one page: start a NEW effort on its own page named after the effort, so concurrent sessions never write over each other and the pane can switch between pages."
@@ -22564,6 +22635,13 @@ function buildServer(stateFile) {
     if (!applied.ok) return text(`refused (nothing changed): ${applied.error}`, true);
     saveMapFile(file, applied.value);
     return text(summarize(applied.value) + (page !== void 0 ? ` [page: ${page}]` : ""));
+  };
+  const setupNudge = () => {
+    const policy = loadMappingPolicy(stateFile);
+    if (!policy.ok) return `
+note: ${describeStoreError(policy.error)} \u2014 fix it or rerun setup (mmap_setup).`;
+    if (policy.value !== void 0) return "";
+    return "\nnote: mapping policy not set for this project. Ask the user when maps should open \u2014 " + MAPPING_POLICIES.map((p) => `${p} (${describeMappingPolicy(p)})`).join("; ") + " \u2014 then record the answer with mmap_setup.";
   };
   server.registerTool(
     "mmap_declare",
@@ -22612,7 +22690,12 @@ function buildServer(stateFile) {
         edges: external_exports.array(EDGE.extend({ label: external_exports.string().max(80).optional().describe("what flows along the edge") })).optional()
       }
     },
-    (input) => mutate(input.page, (map) => applyDeclare(map, input))
+    (input) => {
+      const result = mutate(input.page, (map) => applyDeclare(map, input));
+      if (result.isError === true) return result;
+      const nudge = setupNudge();
+      return nudge === "" ? result : text((result.content[0]?.text ?? "") + nudge);
+    }
   );
   server.registerTool(
     "mmap_update",
@@ -22655,6 +22738,31 @@ function buildServer(stateFile) {
     (input) => mutate(input.page, (map) => applyRemove(map, input))
   );
   server.registerTool(
+    "mmap_setup",
+    {
+      title: "Configure when maps open",
+      description: `Get or set this project's mapping policy \u2014 WHEN the assistant opens a Mellos map. Call with no arguments to read it. If it reports "not set", ask the USER to choose (never pick for them): always = ` + describeMappingPolicy("always") + "; complex = " + describeMappingPolicy("complex") + "; on-request = " + describeMappingPolicy("on-request") + ". Then call again with their choice to persist it. The policy guides you; it never blocks the tools, and an explicit user request for a map always wins.",
+      inputSchema: {
+        policy: external_exports.enum(MAPPING_POLICIES).optional().describe("the user's choice to persist; omit to read the current policy")
+      }
+    },
+    (input) => {
+      if (input.policy !== void 0) {
+        const policy = input.policy;
+        saveMappingPolicy(stateFile, policy);
+        return text(`mapping policy set: ${policy} \u2014 ${describeMappingPolicy(policy)} [${configFilePath(stateFile)}]`);
+      }
+      const loaded = loadMappingPolicy(stateFile);
+      if (!loaded.ok) return text(describeStoreError(loaded.error), true);
+      if (loaded.value === void 0) {
+        return text(
+          "mapping policy not set. Ask the user to choose one of: " + MAPPING_POLICIES.map((p) => `${p} (${describeMappingPolicy(p)})`).join("; ") + " \u2014 then call mmap_setup with their choice. Until then act as complex."
+        );
+      }
+      return text(`mapping policy: ${loaded.value} \u2014 ${describeMappingPolicy(loaded.value)}`);
+    }
+  );
+  server.registerTool(
     "mmap_view",
     {
       title: "View the current map",
@@ -22678,7 +22786,9 @@ function resolveStateFile(env, cwd) {
   return join2(projectDir, STATE_FILE_RELATIVE_PATH);
 }
 async function main() {
-  const server = buildServer(resolveStateFile(process.env, process.cwd()));
+  const stateFile = resolveStateFile(process.env, process.cwd());
+  migrateLegacyStore(stateFile);
+  const server = buildServer(stateFile);
   await server.connect(new StdioServerTransport());
 }
 function launchedAsEntry(argv1, moduleUrl) {

--- a/dist/server.mjs
+++ b/dist/server.mjs
@@ -21388,13 +21388,66 @@ function removeLayer(map, id) {
   return ok({ ...map, layers: map.layers.filter((l) => l.id !== id) });
 }
 
-// src/render/render.ts
+// src/semantics/semantics.ts
 var ZOOM_MIN = -4;
 var ZOOM_MAX = 2;
 var ZOOM_DEFAULT = 0;
 function clampZoom(n) {
   return Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, Math.round(n)));
 }
+function zoomMode(zoom) {
+  if (zoom >= 1) return "detail";
+  if (zoom <= -4) return "overview";
+  return "boxes";
+}
+function isNeutralKind(map) {
+  return map.kind !== void 0 && map.kind !== "dev";
+}
+function aggregateMap(map) {
+  if (map.groups.length === 0) return void 0;
+  const representative = /* @__PURE__ */ new Map();
+  for (const n of map.nodes) representative.set(n.id, n.group ?? n.id);
+  const nodes = map.groups.map((g) => {
+    const members = map.nodes.filter((n) => n.group === g.id);
+    const done = members.filter((n) => n.status === "done").length;
+    return {
+      id: g.id,
+      // neutral kinds document structure, not progress — no member counts
+      label: isNeutralKind(map) ? g.label : `${g.label} ${done}/${members.length}`,
+      layer: g.layer,
+      status: groupStatus(map, g.id)
+    };
+  });
+  for (const n of map.nodes) if (n.group === void 0) nodes.push(n);
+  const seen = /* @__PURE__ */ new Set();
+  const edges = [];
+  for (const e of map.edges) {
+    const from = representative.get(e.from);
+    const to = representative.get(e.to);
+    if (from === to || seen.has(`${from}->${to}`)) continue;
+    seen.add(`${from}->${to}`);
+    edges.push({ from, to });
+  }
+  return {
+    ...map.title !== void 0 ? { title: map.title } : {},
+    ...map.kind !== void 0 ? { kind: map.kind } : {},
+    layers: map.layers,
+    groups: [],
+    lanes: map.lanes,
+    nodes,
+    edges
+  };
+}
+function flipForSequence(map) {
+  if (map.kind !== "sequence") return map;
+  return {
+    ...map,
+    layers: map.layers.map((l) => ({ ...l, rank: -l.rank })),
+    edges: map.edges.map((e) => ({ from: e.to, to: e.from, ...e.label !== void 0 ? { label: e.label } : {} }))
+  };
+}
+
+// src/render/render.ts
 var WIDE_RANGES = [
   [4352, 4447],
   // Hangul Jamo
@@ -21659,9 +21712,6 @@ function kindGlyph(kind, unicode) {
   const pair = NODE_KIND_GLYPHS[kind];
   return pair === void 0 ? void 0 : unicode ? pair[0] : pair[1];
 }
-function isNeutralKind(map) {
-  return map.kind !== void 0 && map.kind !== "dev";
-}
 function neutralSkin(unicode) {
   return unicode ? { h: "\u2500", v: "\u2502", corners: ["\u256D", "\u256E", "\u2570", "\u256F"], style: "none" } : { h: "-", v: "|", corners: ["+", "+", "+", "+"], style: "none" };
 }
@@ -21671,21 +21721,23 @@ var LEFT_MARGIN = 2;
 var DETAIL_BUDGET = { innerMin: 22, innerMax: 32, noteRows: 3 };
 var DETAIL_PLUS_BUDGET = { innerMin: 30, innerMax: 48, noteRows: 12 };
 function zoomGeometry(zoom) {
+  const m = zoomMode(zoom);
+  const mode = m === "overview" ? "constellation" : m;
   switch (zoom) {
     case 2:
-      return { mode: "detail", scale: 1, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false, detail: DETAIL_PLUS_BUDGET };
+      return { mode, scale: 1, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false, detail: DETAIL_PLUS_BUDGET };
     case 1:
-      return { mode: "detail", scale: 1, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false, detail: DETAIL_BUDGET };
+      return { mode, scale: 1, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false, detail: DETAIL_BUDGET };
     case 0:
-      return { mode: "boxes", scale: 1, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false };
+      return { mode, scale: 1, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false };
     case -1:
-      return { mode: "boxes", scale: 0.85, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false };
+      return { mode, scale: 0.85, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false };
     case -2:
-      return { mode: "boxes", scale: 0.7, pad: 0, boxGap: BOX_GAP, breathe: 0, titleGap: 0, barGap: 1, bandCounts: false };
+      return { mode, scale: 0.7, pad: 0, boxGap: BOX_GAP, breathe: 0, titleGap: 0, barGap: 1, bandCounts: false };
     case -3:
-      return { mode: "boxes", scale: 0.55, pad: 0, boxGap: 1, breathe: 0, titleGap: 0, barGap: 1, bandCounts: true };
+      return { mode, scale: 0.55, pad: 0, boxGap: 1, breathe: 0, titleGap: 0, barGap: 1, bandCounts: true };
     case -4:
-      return { mode: "constellation", scale: 0, pad: 0, boxGap: BOX_GAP, breathe: 0, titleGap: 0, barGap: 1, bandCounts: true };
+      return { mode, scale: 0, pad: 0, boxGap: BOX_GAP, breathe: 0, titleGap: 0, barGap: 1, bandCounts: true };
   }
 }
 var LABEL_BUDGET_MIN = 4;
@@ -21733,41 +21785,6 @@ function renderMap(map, opts) {
   const built = buildCanvas(map, opts);
   return built.canvas.emit(opts);
 }
-function aggregateMap(map) {
-  if (map.groups.length === 0) return void 0;
-  const representative = /* @__PURE__ */ new Map();
-  for (const n of map.nodes) representative.set(n.id, n.group ?? n.id);
-  const nodes = map.groups.map((g) => {
-    const members = map.nodes.filter((n) => n.group === g.id);
-    const done = members.filter((n) => n.status === "done").length;
-    return {
-      id: g.id,
-      // neutral kinds document structure, not progress — no member counts
-      label: isNeutralKind(map) ? g.label : `${g.label} ${done}/${members.length}`,
-      layer: g.layer,
-      status: groupStatus(map, g.id)
-    };
-  });
-  for (const n of map.nodes) if (n.group === void 0) nodes.push(n);
-  const seen = /* @__PURE__ */ new Set();
-  const edges = [];
-  for (const e of map.edges) {
-    const from = representative.get(e.from);
-    const to = representative.get(e.to);
-    if (from === to || seen.has(`${from}->${to}`)) continue;
-    seen.add(`${from}->${to}`);
-    edges.push({ from, to });
-  }
-  return {
-    ...map.title !== void 0 ? { title: map.title } : {},
-    ...map.kind !== void 0 ? { kind: map.kind } : {},
-    layers: map.layers,
-    groups: [],
-    lanes: map.lanes,
-    nodes,
-    edges
-  };
-}
 var AGGREGATE_GEO = {
   mode: "boxes",
   scale: 1,
@@ -21778,14 +21795,6 @@ var AGGREGATE_GEO = {
   barGap: 1,
   bandCounts: false
 };
-function flipForSequence(map) {
-  if (map.kind !== "sequence") return map;
-  return {
-    ...map,
-    layers: map.layers.map((l) => ({ ...l, rank: -l.rank })),
-    edges: map.edges.map((e) => ({ from: e.to, to: e.from, ...e.label !== void 0 ? { label: e.label } : {} }))
-  };
-}
 function buildCanvas(map, opts) {
   const oriented = flipForSequence(map);
   const plainGeo = zoomGeometry(opts.zoom ?? ZOOM_DEFAULT);
@@ -22135,63 +22144,9 @@ function drawBox(canvas, box, opts, neutral, focused = false) {
 // src/store/store.ts
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
+
+// src/store/format.ts
 var STATE_FILE_VERSION = 1;
-var STATE_FILE_RELATIVE_PATH = join(".claude", "mellos-mapping.json");
-var PAGES_DIR_NAME = "mellos-mapping.pages";
-function pageFilePath(defaultFile, page) {
-  return page === void 0 ? defaultFile : join(dirname(defaultFile), PAGES_DIR_NAME, `${page}.json`);
-}
-var CONFIG_FILE_NAME = "mellos-mapping.config.json";
-var CONFIG_FILE_VERSION = 1;
-function configFilePath(defaultFile) {
-  return join(dirname(defaultFile), CONFIG_FILE_NAME);
-}
-var MAPPING_POLICIES = ["always", "complex", "on-request"];
-function makeMappingPolicy(raw) {
-  return MAPPING_POLICIES.includes(raw) ? ok(raw) : err({ kind: "invalid-policy", raw, allowed: MAPPING_POLICIES });
-}
-function describeMappingPolicy(policy) {
-  switch (policy) {
-    case "always":
-      return "map every structured task \u2014 workflows, designs, architecture, technical dependencies";
-    case "complex":
-      return "map only medium or complex tasks \u2014 several modules, a new subsystem, roughly an hour or more";
-    case "on-request":
-      return "map only when the user explicitly asks";
-  }
-}
-function loadMappingPolicy(defaultFile) {
-  const path = configFilePath(defaultFile);
-  let text2;
-  try {
-    text2 = readFileSync(path, "utf8");
-  } catch (e) {
-    if (e.code === "ENOENT") return ok(void 0);
-    throw e;
-  }
-  let raw;
-  try {
-    raw = JSON.parse(text2);
-  } catch (e) {
-    return err({ kind: "malformed-json", path, detail: e.message });
-  }
-  if (!isRecord(raw)) return err({ kind: "bad-shape", path, detail: "root is not an object" });
-  if (raw["version"] !== CONFIG_FILE_VERSION) {
-    return err({ kind: "bad-shape", path, detail: `version is ${String(raw["version"])}, expected ${CONFIG_FILE_VERSION}` });
-  }
-  const rawPolicy = raw["policy"];
-  if (rawPolicy === void 0) return ok(void 0);
-  if (typeof rawPolicy !== "string") return err({ kind: "bad-shape", path, detail: "policy is not a string" });
-  const policy = makeMappingPolicy(rawPolicy);
-  return policy.ok ? ok(policy.value) : err({ kind: "bad-shape", path, detail: `policy is "${rawPolicy}", expected one of: ${MAPPING_POLICIES.join(" | ")}` });
-}
-function saveMappingPolicy(defaultFile, policy) {
-  const path = configFilePath(defaultFile);
-  mkdirSync(dirname(path), { recursive: true });
-  const tmp = path + ".tmp";
-  writeFileSync(tmp, JSON.stringify({ version: CONFIG_FILE_VERSION, policy }, null, 2) + "\n", "utf8");
-  renameSync(tmp, path);
-}
 function describeStoreError(e) {
   switch (e.kind) {
     case "not-found":
@@ -22345,6 +22300,13 @@ function serializeMap(map) {
     edges: map.edges
   };
   return JSON.stringify(body, null, 2) + "\n";
+}
+
+// src/store/store.ts
+var STATE_FILE_RELATIVE_PATH = join(".claude", "mellos-mapping.json");
+var PAGES_DIR_NAME = "mellos-mapping.pages";
+function pageFilePath(defaultFile, page) {
+  return page === void 0 ? defaultFile : join(dirname(defaultFile), PAGES_DIR_NAME, `${page}.json`);
 }
 function loadMapFile(path) {
   let text2;
@@ -22566,7 +22528,7 @@ function summarize(map) {
 
 // src/server/server.ts
 var SERVER_NAME = "mellos-mapping";
-var SERVER_VERSION = "0.19.0";
+var SERVER_VERSION = "0.18.0";
 var ID = external_exports.string().regex(/^[a-z0-9][a-z0-9-]{0,63}$/, "lowercase letters, digits and dashes, 1-64 chars").describe("stable kebab-case identifier");
 var PAGE = ID.optional().describe(
   "page (parallel map) this call targets; omit for the default page. One effort = one page: start a NEW effort on its own page named after the effort, so concurrent sessions never write over each other and the pane can switch between pages."
@@ -22602,13 +22564,6 @@ function buildServer(stateFile) {
     if (!applied.ok) return text(`refused (nothing changed): ${applied.error}`, true);
     saveMapFile(file, applied.value);
     return text(summarize(applied.value) + (page !== void 0 ? ` [page: ${page}]` : ""));
-  };
-  const setupNudge = () => {
-    const policy = loadMappingPolicy(stateFile);
-    if (!policy.ok) return `
-note: ${describeStoreError(policy.error)} \u2014 fix it or rerun setup (mmap_setup).`;
-    if (policy.value !== void 0) return "";
-    return "\nnote: mapping policy not set for this project. Ask the user when maps should open \u2014 " + MAPPING_POLICIES.map((p) => `${p} (${describeMappingPolicy(p)})`).join("; ") + " \u2014 then record the answer with mmap_setup.";
   };
   server.registerTool(
     "mmap_declare",
@@ -22657,12 +22612,7 @@ note: ${describeStoreError(policy.error)} \u2014 fix it or rerun setup (mmap_set
         edges: external_exports.array(EDGE.extend({ label: external_exports.string().max(80).optional().describe("what flows along the edge") })).optional()
       }
     },
-    (input) => {
-      const result = mutate(input.page, (map) => applyDeclare(map, input));
-      if (result.isError === true) return result;
-      const nudge = setupNudge();
-      return nudge === "" ? result : text((result.content[0]?.text ?? "") + nudge);
-    }
+    (input) => mutate(input.page, (map) => applyDeclare(map, input))
   );
   server.registerTool(
     "mmap_update",
@@ -22703,31 +22653,6 @@ note: ${describeStoreError(policy.error)} \u2014 fix it or rerun setup (mmap_set
       }
     },
     (input) => mutate(input.page, (map) => applyRemove(map, input))
-  );
-  server.registerTool(
-    "mmap_setup",
-    {
-      title: "Configure when maps open",
-      description: `Get or set this project's mapping policy \u2014 WHEN the assistant opens a Mellos map. Call with no arguments to read it. If it reports "not set", ask the USER to choose (never pick for them): always = ` + describeMappingPolicy("always") + "; complex = " + describeMappingPolicy("complex") + "; on-request = " + describeMappingPolicy("on-request") + ". Then call again with their choice to persist it. The policy guides you; it never blocks the tools, and an explicit user request for a map always wins.",
-      inputSchema: {
-        policy: external_exports.enum(MAPPING_POLICIES).optional().describe("the user's choice to persist; omit to read the current policy")
-      }
-    },
-    (input) => {
-      if (input.policy !== void 0) {
-        const policy = input.policy;
-        saveMappingPolicy(stateFile, policy);
-        return text(`mapping policy set: ${policy} \u2014 ${describeMappingPolicy(policy)} [${configFilePath(stateFile)}]`);
-      }
-      const loaded = loadMappingPolicy(stateFile);
-      if (!loaded.ok) return text(describeStoreError(loaded.error), true);
-      if (loaded.value === void 0) {
-        return text(
-          "mapping policy not set. Ask the user to choose one of: " + MAPPING_POLICIES.map((p) => `${p} (${describeMappingPolicy(p)})`).join("; ") + " \u2014 then call mmap_setup with their choice. Until then act as complex."
-        );
-      }
-      return text(`mapping policy: ${loaded.value} \u2014 ${describeMappingPolicy(loaded.value)}`);
-    }
   );
   server.registerTool(
     "mmap_view",

--- a/dist/watch.mjs
+++ b/dist/watch.mjs
@@ -267,6 +267,88 @@ function aggregateMap(map) {
     edges
   };
 }
+function focusInfo(map, focusId) {
+  const layerNameOf = (layerId) => map.layers.find((l) => l.id === layerId)?.name ?? layerId;
+  const group = map.groups.find((g) => g.id === focusId);
+  if (group) {
+    const members = map.nodes.filter((n) => n.group === group.id);
+    const memberIds = new Set(members.map((n) => n.id));
+    const rep = (id) => {
+      const n = map.nodes.find((x) => x.id === id);
+      const owner = n.group !== void 0 ? map.groups.find((g) => g.id === n.group) : void 0;
+      return owner !== void 0 ? { id: owner.id, label: owner.label, status: groupStatus(map, owner.id) } : { id: n.id, label: n.label, status: n.status };
+    };
+    const dedupe = (refs) => {
+      const seen = /* @__PURE__ */ new Set();
+      const out = [];
+      for (const r of refs) {
+        if (seen.has(r.id)) continue;
+        seen.add(r.id);
+        out.push(r);
+      }
+      return out;
+    };
+    return {
+      kind: "group",
+      group,
+      status: groupStatus(map, group.id),
+      layerName: layerNameOf(group.layer),
+      members,
+      uses: dedupe(
+        map.edges.filter((e) => memberIds.has(e.from) && !memberIds.has(e.to)).map((e) => rep(e.to))
+      ),
+      usedBy: dedupe(
+        map.edges.filter((e) => memberIds.has(e.to) && !memberIds.has(e.from)).map((e) => rep(e.from))
+      )
+    };
+  }
+  const node = map.nodes.find((n) => n.id === focusId);
+  if (!node) return void 0;
+  const ref = (id, edgeLabel) => {
+    const n = map.nodes.find((x) => x.id === id);
+    return {
+      id,
+      label: n?.label ?? id,
+      status: n?.status ?? "planned",
+      ...edgeLabel !== void 0 ? { edgeLabel } : {}
+    };
+  };
+  const laneLabel = node.lane !== void 0 ? map.lanes.find((l) => l.id === node.lane)?.label : void 0;
+  return {
+    kind: "node",
+    node,
+    layerName: layerNameOf(node.layer),
+    ...laneLabel !== void 0 ? { laneLabel } : {},
+    uses: map.edges.filter((e) => e.from === node.id).map((e) => ref(e.to, e.label)),
+    usedBy: map.edges.filter((e) => e.to === node.id).map((e) => ref(e.from, e.label))
+  };
+}
+function submapRefs(maps) {
+  const refs = /* @__PURE__ */ new Set();
+  for (const m of maps) {
+    for (const n of m?.nodes ?? []) if (n.submap !== void 0) refs.add(n.submap);
+  }
+  return refs;
+}
+function diveParent(entries, pageId) {
+  for (const [key, m] of entries) {
+    const node = m?.nodes.find((n) => n.submap === pageId);
+    if (node !== void 0) return { parent: key, label: node.label };
+  }
+  return void 0;
+}
+function mostRecentKey(keys, mtimeOf) {
+  let best;
+  let bestMtime = -Infinity;
+  for (const key of keys) {
+    const mtime = mtimeOf(key);
+    if (mtime !== void 0 && mtime > bestMtime) {
+      best = key;
+      bestMtime = mtime;
+    }
+  }
+  return best ?? keys[0];
+}
 function flipForSequence(map) {
   if (map.kind !== "sequence") return map;
   return {
@@ -1333,16 +1415,7 @@ function dividerRow(width, unicode, follow) {
   return bar;
 }
 function mostRecentPageFile(files, mtimeOf) {
-  let best;
-  let bestMtime = -Infinity;
-  for (const file of files) {
-    const mtime = mtimeOf(file);
-    if (mtime !== void 0 && mtime > bestMtime) {
-      best = file;
-      bestMtime = mtime;
-    }
-  }
-  return best ?? files[0];
+  return mostRecentKey(files, mtimeOf);
 }
 var HIDE_CURSOR = "\x1B[?25l";
 var SHOW_CURSOR = "\x1B[?25h";
@@ -1430,10 +1503,7 @@ function tabScrollFor(tabs, width, unicode, scroll, index) {
   return s;
 }
 function topLevelFiles(defaultFile, files, mapOf) {
-  const refs = /* @__PURE__ */ new Set();
-  for (const m of mapOf.values()) {
-    for (const n of m?.nodes ?? []) if (n.submap !== void 0) refs.add(n.submap);
-  }
+  const refs = submapRefs(mapOf.values());
   return files.filter((f) => {
     const id = pageIdOfFile(defaultFile, f);
     return id === void 0 || !refs.has(id);
@@ -1442,12 +1512,8 @@ function topLevelFiles(defaultFile, files, mapOf) {
 function diveOrigin(defaultFile, file, files, mapOf) {
   const id = pageIdOfFile(defaultFile, file);
   if (id === void 0) return void 0;
-  for (const f of files) {
-    if (f === file) continue;
-    const node = mapOf.get(f)?.nodes.find((n) => n.submap === id);
-    if (node !== void 0) return { parent: f, label: node.label };
-  }
-  return void 0;
+  const entries = files.filter((f) => f !== file).map((f) => [f, mapOf.get(f)]);
+  return diveParent(entries, id);
 }
 function nearestHit(hits, cx, cy) {
   let best;
@@ -1464,28 +1530,14 @@ function nearestHit(hits, cx, cy) {
 function nodePanel(map, focusId, unicode, width, pinned, rows = PANEL_CONTENT_ROWS) {
   const g = (s) => STATUS_GLYPH[s][unicode ? 0 : 1];
   const pinMark = pinned ? unicode ? "  \u2299 pinned" : "  * pinned" : "";
-  const group = map.groups.find((gr) => gr.id === focusId);
-  if (group) {
-    const members = map.nodes.filter((n) => n.group === group.id);
-    const memberIds = new Set(members.map((n) => n.id));
-    const status = groupStatus(map, group.id);
-    const layerName2 = map.layers.find((l) => l.id === group.layer)?.name ?? group.layer;
+  const focus = focusInfo(map, focusId);
+  if (focus === void 0) return void 0;
+  const refText = (r) => `${g(r.status)} ${r.label}${r.edgeLabel !== void 0 ? ` (${r.edgeLabel})` : ""}`;
+  if (focus.kind === "group") {
+    const { group, status, layerName: layerName2, members } = focus;
     const [right2, left2] = unicode ? ["\u2192", "\u2190"] : ["->", "<-"];
-    const repLabel = (id) => {
-      const n = map.nodes.find((x) => x.id === id);
-      const owner = n.group !== void 0 ? map.groups.find((gr) => gr.id === n.group) : void 0;
-      return owner !== void 0 ? `${g(groupStatus(map, owner.id))} ${owner.label}` : `${g(n.status)} ${n.label}`;
-    };
-    const uses2 = [
-      ...new Set(
-        map.edges.filter((e) => memberIds.has(e.from) && !memberIds.has(e.to)).map((e) => repLabel(e.to))
-      )
-    ];
-    const usedBy2 = [
-      ...new Set(
-        map.edges.filter((e) => memberIds.has(e.to) && !memberIds.has(e.from)).map((e) => repLabel(e.from))
-      )
-    ];
+    const uses2 = focus.uses.map(refText);
+    const usedBy2 = focus.usedBy.map(refText);
     const lines2 = [
       {
         text: fitWidth(
@@ -1504,21 +1556,13 @@ function nodePanel(map, focusId, unicode, width, pinned, rows = PANEL_CONTENT_RO
     while (lines2.length < rows) lines2.push({ text: "", sgr: "" });
     return lines2.slice(0, rows);
   }
-  const node = map.nodes.find((n) => n.id === focusId);
-  if (!node) return void 0;
+  const { node, layerName, laneLabel } = focus;
   const neutral = isNeutralKind(map);
-  const layerName = map.layers.find((l) => l.id === node.layer)?.name ?? node.layer;
   const [right, left] = unicode ? ["\u2192", "\u2190"] : ["->", "<-"];
-  const withGlyph = (id) => {
-    const n = map.nodes.find((x) => x.id === id);
-    return n ? `${g(n.status)} ${n.label}` : id;
-  };
-  const withEdgeLabel = (base, label) => label !== void 0 ? `${base} (${label})` : base;
-  const uses = map.edges.filter((e) => e.from === node.id).map((e) => withEdgeLabel(withGlyph(e.to), e.label));
-  const usedBy = map.edges.filter((e) => e.to === node.id).map((e) => withEdgeLabel(withGlyph(e.from), e.label));
-  const pin = pinned ? unicode ? "  \u2299 pinned" : "  * pinned" : "";
+  const uses = focus.uses.map(refText);
+  const usedBy = focus.usedBy.map(refText);
+  const pin = pinMark;
   const headGlyph = neutral ? (node.kind !== void 0 ? kindGlyph(node.kind, unicode) : void 0) ?? (unicode ? "\xB7" : ".") : g(node.status);
-  const laneLabel = node.lane !== void 0 ? map.lanes.find((l) => l.id === node.lane)?.label : void 0;
   const headParts = [
     `${headGlyph} ${node.label} [${node.id}]`,
     layerName,

--- a/dist/watch.mjs
+++ b/dist/watch.mjs
@@ -1209,8 +1209,8 @@ function parseMap(raw, path) {
 }
 
 // src/store/store.ts
-var STATE_FILE_RELATIVE_PATH = join(".claude", "mellos-mapping.json");
-var PAGES_DIR_NAME = "mellos-mapping.pages";
+var STATE_FILE_RELATIVE_PATH = join(".mellos", "map.json");
+var PAGES_DIR_NAME = "pages";
 function pageFilePath(defaultFile, page) {
   return page === void 0 ? defaultFile : join(dirname(defaultFile), PAGES_DIR_NAME, `${page}.json`);
 }
@@ -1232,7 +1232,7 @@ function listPageFiles(defaultFile) {
   }
   return out;
 }
-var FOCUS_FILE_NAME = "mellos-mapping.focus";
+var FOCUS_FILE_NAME = "focus";
 function focusFilePath(defaultFile) {
   return join(dirname(defaultFile), FOCUS_FILE_NAME);
 }
@@ -1260,6 +1260,27 @@ function takeFocusRequest(defaultFile) {
   if (typeof page !== "string") return void 0;
   const id = makePageId(page);
   return id.ok ? { page: id.value } : void 0;
+}
+var CONFIG_FILE_NAME = "config.json";
+function configFilePath(defaultFile) {
+  return join(dirname(defaultFile), CONFIG_FILE_NAME);
+}
+var LEGACY_STATE_FILE_RELATIVE_PATH = join(".claude", "mellos-mapping.json");
+var LEGACY_PAGES_DIR_NAME = "mellos-mapping.pages";
+var LEGACY_CONFIG_FILE_NAME = "mellos-mapping.config.json";
+function migrateLegacyStore(defaultFile) {
+  const projectRoot = dirname(dirname(defaultFile));
+  const legacyDefault = join(projectRoot, LEGACY_STATE_FILE_RELATIVE_PATH);
+  const legacyPages = join(dirname(legacyDefault), LEGACY_PAGES_DIR_NAME);
+  const legacyConfig = join(dirname(legacyDefault), LEGACY_CONFIG_FILE_NAME);
+  const hasLegacy = existsSync(legacyDefault) || existsSync(legacyPages) || existsSync(legacyConfig);
+  const hasCurrent = existsSync(defaultFile) || existsSync(join(dirname(defaultFile), PAGES_DIR_NAME)) || existsSync(configFilePath(defaultFile));
+  if (!hasLegacy || hasCurrent) return false;
+  mkdirSync(dirname(defaultFile), { recursive: true });
+  if (existsSync(legacyDefault)) renameSync(legacyDefault, defaultFile);
+  if (existsSync(legacyPages)) renameSync(legacyPages, join(dirname(defaultFile), PAGES_DIR_NAME));
+  if (existsSync(legacyConfig)) renameSync(legacyConfig, configFilePath(defaultFile));
+  return true;
 }
 function loadMapFile(path) {
   let text;
@@ -1729,6 +1750,7 @@ function mapPanel(map, unicode, width, rows = PANEL_CONTENT_ROWS) {
 }
 function main() {
   const cfg = parseArgs(process.argv.slice(2), process.cwd());
+  migrateLegacyStore(cfg.file);
   const interactive = process.stdin.isTTY === true && process.stdout.isTTY === true;
   const mouseActive = interactive && cfg.mouse;
   let lastFrame = "";

--- a/dist/watch.mjs
+++ b/dist/watch.mjs
@@ -199,12 +199,17 @@ function updateNode(map, input) {
   return ok({ ...map, nodes: map.nodes.map((n) => n.id === input.id ? updated : n) });
 }
 
-// src/render/render.ts
+// src/semantics/semantics.ts
 var ZOOM_MIN = -4;
 var ZOOM_MAX = 2;
 var ZOOM_DEFAULT = 0;
 function clampZoom(n) {
   return Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, Math.round(n)));
+}
+function zoomMode(zoom) {
+  if (zoom >= 1) return "detail";
+  if (zoom <= -4) return "overview";
+  return "boxes";
 }
 function zoomLabel(zoom) {
   switch (zoom) {
@@ -224,6 +229,54 @@ function zoomLabel(zoom) {
       return "overview";
   }
 }
+function isNeutralKind(map) {
+  return map.kind !== void 0 && map.kind !== "dev";
+}
+function aggregateMap(map) {
+  if (map.groups.length === 0) return void 0;
+  const representative = /* @__PURE__ */ new Map();
+  for (const n of map.nodes) representative.set(n.id, n.group ?? n.id);
+  const nodes = map.groups.map((g) => {
+    const members = map.nodes.filter((n) => n.group === g.id);
+    const done = members.filter((n) => n.status === "done").length;
+    return {
+      id: g.id,
+      // neutral kinds document structure, not progress — no member counts
+      label: isNeutralKind(map) ? g.label : `${g.label} ${done}/${members.length}`,
+      layer: g.layer,
+      status: groupStatus(map, g.id)
+    };
+  });
+  for (const n of map.nodes) if (n.group === void 0) nodes.push(n);
+  const seen = /* @__PURE__ */ new Set();
+  const edges = [];
+  for (const e of map.edges) {
+    const from = representative.get(e.from);
+    const to = representative.get(e.to);
+    if (from === to || seen.has(`${from}->${to}`)) continue;
+    seen.add(`${from}->${to}`);
+    edges.push({ from, to });
+  }
+  return {
+    ...map.title !== void 0 ? { title: map.title } : {},
+    ...map.kind !== void 0 ? { kind: map.kind } : {},
+    layers: map.layers,
+    groups: [],
+    lanes: map.lanes,
+    nodes,
+    edges
+  };
+}
+function flipForSequence(map) {
+  if (map.kind !== "sequence") return map;
+  return {
+    ...map,
+    layers: map.layers.map((l) => ({ ...l, rank: -l.rank })),
+    edges: map.edges.map((e) => ({ from: e.to, to: e.from, ...e.label !== void 0 ? { label: e.label } : {} }))
+  };
+}
+
+// src/render/render.ts
 var WIDE_RANGES = [
   [4352, 4447],
   // Hangul Jamo
@@ -488,9 +541,6 @@ function kindGlyph(kind, unicode) {
   const pair = NODE_KIND_GLYPHS[kind];
   return pair === void 0 ? void 0 : unicode ? pair[0] : pair[1];
 }
-function isNeutralKind(map) {
-  return map.kind !== void 0 && map.kind !== "dev";
-}
 function neutralSkin(unicode) {
   return unicode ? { h: "\u2500", v: "\u2502", corners: ["\u256D", "\u256E", "\u2570", "\u256F"], style: "none" } : { h: "-", v: "|", corners: ["+", "+", "+", "+"], style: "none" };
 }
@@ -500,21 +550,23 @@ var LEFT_MARGIN = 2;
 var DETAIL_BUDGET = { innerMin: 22, innerMax: 32, noteRows: 3 };
 var DETAIL_PLUS_BUDGET = { innerMin: 30, innerMax: 48, noteRows: 12 };
 function zoomGeometry(zoom) {
+  const m = zoomMode(zoom);
+  const mode = m === "overview" ? "constellation" : m;
   switch (zoom) {
     case 2:
-      return { mode: "detail", scale: 1, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false, detail: DETAIL_PLUS_BUDGET };
+      return { mode, scale: 1, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false, detail: DETAIL_PLUS_BUDGET };
     case 1:
-      return { mode: "detail", scale: 1, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false, detail: DETAIL_BUDGET };
+      return { mode, scale: 1, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false, detail: DETAIL_BUDGET };
     case 0:
-      return { mode: "boxes", scale: 1, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false };
+      return { mode, scale: 1, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false };
     case -1:
-      return { mode: "boxes", scale: 0.85, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false };
+      return { mode, scale: 0.85, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false };
     case -2:
-      return { mode: "boxes", scale: 0.7, pad: 0, boxGap: BOX_GAP, breathe: 0, titleGap: 0, barGap: 1, bandCounts: false };
+      return { mode, scale: 0.7, pad: 0, boxGap: BOX_GAP, breathe: 0, titleGap: 0, barGap: 1, bandCounts: false };
     case -3:
-      return { mode: "boxes", scale: 0.55, pad: 0, boxGap: 1, breathe: 0, titleGap: 0, barGap: 1, bandCounts: true };
+      return { mode, scale: 0.55, pad: 0, boxGap: 1, breathe: 0, titleGap: 0, barGap: 1, bandCounts: true };
     case -4:
-      return { mode: "constellation", scale: 0, pad: 0, boxGap: BOX_GAP, breathe: 0, titleGap: 0, barGap: 1, bandCounts: true };
+      return { mode, scale: 0, pad: 0, boxGap: BOX_GAP, breathe: 0, titleGap: 0, barGap: 1, bandCounts: true };
   }
 }
 var LABEL_BUDGET_MIN = 4;
@@ -567,41 +619,6 @@ function renderMapWindow(map, opts, viewport) {
     hits: built.hits
   };
 }
-function aggregateMap(map) {
-  if (map.groups.length === 0) return void 0;
-  const representative = /* @__PURE__ */ new Map();
-  for (const n of map.nodes) representative.set(n.id, n.group ?? n.id);
-  const nodes = map.groups.map((g) => {
-    const members = map.nodes.filter((n) => n.group === g.id);
-    const done = members.filter((n) => n.status === "done").length;
-    return {
-      id: g.id,
-      // neutral kinds document structure, not progress — no member counts
-      label: isNeutralKind(map) ? g.label : `${g.label} ${done}/${members.length}`,
-      layer: g.layer,
-      status: groupStatus(map, g.id)
-    };
-  });
-  for (const n of map.nodes) if (n.group === void 0) nodes.push(n);
-  const seen = /* @__PURE__ */ new Set();
-  const edges = [];
-  for (const e of map.edges) {
-    const from = representative.get(e.from);
-    const to = representative.get(e.to);
-    if (from === to || seen.has(`${from}->${to}`)) continue;
-    seen.add(`${from}->${to}`);
-    edges.push({ from, to });
-  }
-  return {
-    ...map.title !== void 0 ? { title: map.title } : {},
-    ...map.kind !== void 0 ? { kind: map.kind } : {},
-    layers: map.layers,
-    groups: [],
-    lanes: map.lanes,
-    nodes,
-    edges
-  };
-}
 var AGGREGATE_GEO = {
   mode: "boxes",
   scale: 1,
@@ -612,14 +629,6 @@ var AGGREGATE_GEO = {
   barGap: 1,
   bandCounts: false
 };
-function flipForSequence(map) {
-  if (map.kind !== "sequence") return map;
-  return {
-    ...map,
-    layers: map.layers.map((l) => ({ ...l, rank: -l.rank })),
-    edges: map.edges.map((e) => ({ from: e.to, to: e.from, ...e.label !== void 0 ? { label: e.label } : {} }))
-  };
-}
 function buildCanvas(map, opts) {
   const oriented = flipForSequence(map);
   const plainGeo = zoomGeometry(opts.zoom ?? ZOOM_DEFAULT);
@@ -969,61 +978,11 @@ function drawBox(canvas, box, opts, neutral, focused = false) {
 // src/store/store.ts
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
+
+// src/store/format.ts
 var STATE_FILE_VERSION = 1;
-var STATE_FILE_RELATIVE_PATH = join(".claude", "mellos-mapping.json");
-var PAGES_DIR_NAME = "mellos-mapping.pages";
 function makePageId(raw) {
   return ID_RULE.test(raw) ? ok(raw) : err({ kind: "invalid-id", raw, rule: ID_RULE_TEXT });
-}
-function pageFilePath(defaultFile, page) {
-  return page === void 0 ? defaultFile : join(dirname(defaultFile), PAGES_DIR_NAME, `${page}.json`);
-}
-function pageIdOfFile(defaultFile, path) {
-  if (path === defaultFile) return void 0;
-  const name = basename(path);
-  return name.endsWith(".json") ? name.slice(0, -".json".length) : name;
-}
-function listPageFiles(defaultFile) {
-  const out = [];
-  if (existsSync(defaultFile)) out.push(defaultFile);
-  let entries = [];
-  try {
-    entries = readdirSync(join(dirname(defaultFile), PAGES_DIR_NAME));
-  } catch {
-  }
-  for (const e of entries.sort()) {
-    if (e.endsWith(".json")) out.push(join(dirname(defaultFile), PAGES_DIR_NAME, e));
-  }
-  return out;
-}
-var FOCUS_FILE_NAME = "mellos-mapping.focus";
-function focusFilePath(defaultFile) {
-  return join(dirname(defaultFile), FOCUS_FILE_NAME);
-}
-function takeFocusRequest(defaultFile) {
-  const path = focusFilePath(defaultFile);
-  let raw;
-  try {
-    raw = readFileSync(path, "utf8");
-  } catch {
-    return void 0;
-  }
-  try {
-    rmSync(path, { force: true });
-  } catch {
-  }
-  let parsed;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return void 0;
-  }
-  if (typeof parsed !== "object" || parsed === null) return void 0;
-  const page = parsed.page;
-  if (page === void 0 || page === null) return { page: void 0 };
-  if (typeof page !== "string") return void 0;
-  const id = makePageId(page);
-  return id.ok ? { page: id.value } : void 0;
 }
 function describeStoreError(e) {
   switch (e.kind) {
@@ -1165,6 +1124,60 @@ function parseMap(raw, path) {
     map = linked.value;
   }
   return ok(map);
+}
+
+// src/store/store.ts
+var STATE_FILE_RELATIVE_PATH = join(".claude", "mellos-mapping.json");
+var PAGES_DIR_NAME = "mellos-mapping.pages";
+function pageFilePath(defaultFile, page) {
+  return page === void 0 ? defaultFile : join(dirname(defaultFile), PAGES_DIR_NAME, `${page}.json`);
+}
+function pageIdOfFile(defaultFile, path) {
+  if (path === defaultFile) return void 0;
+  const name = basename(path);
+  return name.endsWith(".json") ? name.slice(0, -".json".length) : name;
+}
+function listPageFiles(defaultFile) {
+  const out = [];
+  if (existsSync(defaultFile)) out.push(defaultFile);
+  let entries = [];
+  try {
+    entries = readdirSync(join(dirname(defaultFile), PAGES_DIR_NAME));
+  } catch {
+  }
+  for (const e of entries.sort()) {
+    if (e.endsWith(".json")) out.push(join(dirname(defaultFile), PAGES_DIR_NAME, e));
+  }
+  return out;
+}
+var FOCUS_FILE_NAME = "mellos-mapping.focus";
+function focusFilePath(defaultFile) {
+  return join(dirname(defaultFile), FOCUS_FILE_NAME);
+}
+function takeFocusRequest(defaultFile) {
+  const path = focusFilePath(defaultFile);
+  let raw;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return void 0;
+  }
+  try {
+    rmSync(path, { force: true });
+  } catch {
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return void 0;
+  }
+  if (typeof parsed !== "object" || parsed === null) return void 0;
+  const page = parsed.page;
+  if (page === void 0 || page === null) return { page: void 0 };
+  if (typeof page !== "string") return void 0;
+  const id = makePageId(page);
+  return id.ok ? { page: id.value } : void 0;
 }
 function loadMapFile(path) {
   let text;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mellos-mapping",
-  "version": "0.19.0",
+  "version": "0.20.0-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mellos-mapping",
-      "version": "0.19.0",
+      "version": "0.20.0-dev.0",
       "license": "MIT",
       "bin": {
         "mellos-mapping": "dist/server.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mellos-mapping",
-  "version": "0.19.0",
+  "version": "0.20.0-dev.0",
   "mcpName": "io.github.GuangminJu/mellos-mapping",
   "description": "A live layered dependency map for bottom-up development — MCP server + terminal pane. Ghost the design first, then light nodes up from the bottom as they are built and verified.",
   "type": "module",
@@ -28,12 +28,30 @@
     "mellos-mapping-watch": "dist/watch.mjs"
   },
   "exports": {
-    "./domain/types": { "types": "./lib/domain/types.d.ts", "default": "./lib/domain/types.js" },
-    "./domain/ops": { "types": "./lib/domain/ops.d.ts", "default": "./lib/domain/ops.js" },
-    "./format": { "types": "./lib/store/format.d.ts", "default": "./lib/store/format.js" },
-    "./store": { "types": "./lib/store/store.d.ts", "default": "./lib/store/store.js" },
-    "./semantics": { "types": "./lib/semantics/semantics.d.ts", "default": "./lib/semantics/semantics.js" },
-    "./render": { "types": "./lib/render/render.d.ts", "default": "./lib/render/render.js" },
+    "./domain/types": {
+      "types": "./lib/domain/types.d.ts",
+      "default": "./lib/domain/types.js"
+    },
+    "./domain/ops": {
+      "types": "./lib/domain/ops.d.ts",
+      "default": "./lib/domain/ops.js"
+    },
+    "./format": {
+      "types": "./lib/store/format.d.ts",
+      "default": "./lib/store/format.js"
+    },
+    "./store": {
+      "types": "./lib/store/store.d.ts",
+      "default": "./lib/store/store.js"
+    },
+    "./semantics": {
+      "types": "./lib/semantics/semantics.d.ts",
+      "default": "./lib/semantics/semantics.js"
+    },
+    "./render": {
+      "types": "./lib/render/render.d.ts",
+      "default": "./lib/render/render.js"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -27,11 +27,21 @@
     "mellos-mapping": "dist/server.mjs",
     "mellos-mapping-watch": "dist/watch.mjs"
   },
+  "exports": {
+    "./domain/types": { "types": "./lib/domain/types.d.ts", "default": "./lib/domain/types.js" },
+    "./domain/ops": { "types": "./lib/domain/ops.d.ts", "default": "./lib/domain/ops.js" },
+    "./format": { "types": "./lib/store/format.d.ts", "default": "./lib/store/format.js" },
+    "./store": { "types": "./lib/store/store.d.ts", "default": "./lib/store/store.js" },
+    "./semantics": { "types": "./lib/semantics/semantics.d.ts", "default": "./lib/semantics/semantics.js" },
+    "./render": { "types": "./lib/render/render.d.ts", "default": "./lib/render/render.js" },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
   "files": [
     "dist",
+    "lib",
     "README.zh-CN.md",
     "scripts/codex-register.mjs",
     "scripts/open-pane.mjs"
@@ -42,7 +52,7 @@
   "scripts": {
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
-    "build": "node build.mjs",
+    "build": "node build.mjs && tsc -p tsconfig.lib.json",
     "verify": "npm run typecheck && npm run test && npm run build"
   },
   "devDependencies": {

--- a/scripts/codex-register.mjs
+++ b/scripts/codex-register.mjs
@@ -45,4 +45,4 @@ if (added.error !== undefined || added.status !== 0) {
 }
 process.stdout.write(added.stdout ?? '');
 console.log(`mellos-mapping MCP registered with Codex: node ${serverPath}`);
-console.log('State files resolve to each session’s working directory (.claude/mellos-mapping.json).');
+console.log('State files resolve to each session’s working directory (.mellos/map.json).');

--- a/scripts/open-pane.mjs
+++ b/scripts/open-pane.mjs
@@ -84,7 +84,7 @@ if (!existsSync(watchPath)) {
   console.error(`watcher not found (is the plugin built?): ${watchPath}`);
   process.exit(1);
 }
-const mapFile = join(projectDir, '.claude', 'mellos-mapping.json');
+const mapFile = join(projectDir, '.mellos', 'map.json');
 
 function runPowerShell(script) {
   const encoded = Buffer.from(script, 'utf16le').toString('base64');

--- a/skills/mellos-mapping/SKILL.md
+++ b/skills/mellos-mapping/SKILL.md
@@ -16,8 +16,8 @@ description: >-
 Five MCP tools (`mmap_declare`, `mmap_update`, `mmap_remove`, `mmap_view`,
 `mmap_setup`)
 maintain a **Mellos map**: a layered dependency map of the system under
-construction, persisted in `.claude/mellos-mapping.json` (default page) plus
-`.claude/mellos-mapping.pages/<slug>.json` (named pages) and rendered live in
+construction, persisted in `.mellos/map.json` (default page) plus
+`.mellos/pages/<slug>.json` (named pages) and rendered live in
 a terminal split pane beside the conversation. To learn whether a map already
 exists, call `mmap_view` — do not probe the default file, which is absent
 when all work lives on named pages.

--- a/src/browser-safe.test.ts
+++ b/src/browser-safe.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Gate: the library's browser-safe entry points must stay free of Node
+ * builtins, transitively. These are the modules the package exports for
+ * browser consumption (a web map panel imports format + semantics + domain);
+ * a `node:*` import anywhere in their closure would break that consumer at
+ * bundle time. ./store and ./render are deliberately absent: store is the
+ * Node half by contract, and the terminal renderer is Node-flavored only by
+ * audience, not imports — keep the promise scoped to what browsers need.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const BROWSER_SAFE_ENTRIES = [
+  'src/domain/types.ts',
+  'src/domain/ops.ts',
+  'src/store/format.ts',
+  'src/semantics/semantics.ts',
+];
+
+/** Static import/export-from specifiers of one TypeScript module. */
+function importSpecifiers(source: string): string[] {
+  const out: string[] = [];
+  for (const m of source.matchAll(/(?:^|\n)\s*(?:import|export)\s[^;]*?from\s+'([^']+)'/g)) {
+    out.push(m[1]!);
+  }
+  return out;
+}
+
+describe('browser-safe library surface', () => {
+  it('imports no Node builtins, transitively', () => {
+    const root = resolve(import.meta.dirname, '..');
+    const visited = new Set<string>();
+    const queue = BROWSER_SAFE_ENTRIES.map((e) => resolve(root, e));
+    const offenders: string[] = [];
+
+    while (queue.length > 0) {
+      const file = queue.pop()!;
+      if (visited.has(file)) continue;
+      visited.add(file);
+      const source = readFileSync(file, 'utf8');
+      for (const spec of importSpecifiers(source)) {
+        if (spec.startsWith('node:')) {
+          offenders.push(`${file} imports ${spec}`);
+        } else if (spec.startsWith('.')) {
+          // TS sources import with a .js extension; follow the .ts sibling.
+          queue.push(join(dirname(file), spec.replace(/\.js$/, '.ts')));
+        } else {
+          // A bare specifier would be a dependency browsers must resolve;
+          // the browser-safe closure has none today, so any appearance is a
+          // deliberate decision to make here, not silently.
+          offenders.push(`${file} imports bare specifier ${spec}`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+    // The closure really covered the entries plus their shared domain deps.
+    expect(visited.size).toBeGreaterThanOrEqual(BROWSER_SAFE_ENTRIES.length);
+  });
+});

--- a/src/render/render.ts
+++ b/src/render/render.ts
@@ -48,39 +48,12 @@
  * box spec (size, border, content) and the whitespace geometry change.
  */
 
-import { groupStatus } from '../domain/ops.js';
-import type { DepEdge, MapNode, MellosMap, NodeId, NodeStatus } from '../domain/types.js';
+import type { MapNode, MellosMap, NodeStatus } from '../domain/types.js';
+import { type ZoomStep, ZOOM_DEFAULT, aggregateMap, flipForSequence, isNeutralKind, zoomMode } from '../semantics/semantics.js';
 
-/** One wheel tick on the zoom ladder; see module header. */
-export type ZoomStep = -4 | -3 | -2 | -1 | 0 | 1 | 2;
-
-export const ZOOM_MIN: ZoomStep = -4;
-export const ZOOM_MAX: ZoomStep = 2;
-export const ZOOM_DEFAULT: ZoomStep = 0;
-
-export function clampZoom(n: number): ZoomStep {
-  return Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, Math.round(n))) as ZoomStep;
-}
-
-/** What the footer shows: a percentage while scaling, a mode name at the ends. */
-export function zoomLabel(zoom: ZoomStep): string {
-  switch (zoom) {
-    case 2:
-      return 'detail+';
-    case 1:
-      return 'detail';
-    case 0:
-      return '100%';
-    case -1:
-      return '85%';
-    case -2:
-      return '70%';
-    case -3:
-      return '55%';
-    case -4:
-      return 'overview';
-  }
-}
+// The view-semantics vocabulary (zoom ladder, neutral-kind rule) is defined in
+// ../semantics and re-exported here so terminal consumers keep one import site.
+export { type ZoomStep, ZOOM_DEFAULT, ZOOM_MAX, ZOOM_MIN, clampZoom, isNeutralKind, zoomLabel } from '../semantics/semantics.js';
 
 export interface RenderOptions {
   /** Emit ANSI color codes. */
@@ -456,11 +429,6 @@ export function kindGlyph(kind: string, unicode: boolean): string | undefined {
   return pair === undefined ? undefined : unicode ? pair[0] : pair[1];
 }
 
-/** Documentation kinds render neutrally: no status skins, no progress counts. */
-export function isNeutralKind(map: MellosMap): boolean {
-  return map.kind !== undefined && map.kind !== 'dev';
-}
-
 /** Plain solid box for documentation diagrams — presence, not progress. */
 function neutralSkin(unicode: boolean): BoxSkin {
   return unicode
@@ -510,21 +478,25 @@ interface ZoomGeometry {
 }
 
 function zoomGeometry(zoom: ZoomStep): ZoomGeometry {
+  // WHICH steps switch mode is semantics (zoomMode); this table owns only the
+  // whitespace and label budgets each step buys in terminal cells.
+  const m = zoomMode(zoom);
+  const mode = m === 'overview' ? 'constellation' : m;
   switch (zoom) {
     case 2:
-      return { mode: 'detail', scale: 1, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false, detail: DETAIL_PLUS_BUDGET };
+      return { mode, scale: 1, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false, detail: DETAIL_PLUS_BUDGET };
     case 1:
-      return { mode: 'detail', scale: 1, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false, detail: DETAIL_BUDGET };
+      return { mode, scale: 1, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false, detail: DETAIL_BUDGET };
     case 0:
-      return { mode: 'boxes', scale: 1, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false };
+      return { mode, scale: 1, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false };
     case -1:
-      return { mode: 'boxes', scale: 0.85, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false };
+      return { mode, scale: 0.85, pad: 1, boxGap: BOX_GAP, breathe: 1, titleGap: 1, barGap: 1, bandCounts: false };
     case -2:
-      return { mode: 'boxes', scale: 0.7, pad: 0, boxGap: BOX_GAP, breathe: 0, titleGap: 0, barGap: 1, bandCounts: false };
+      return { mode, scale: 0.7, pad: 0, boxGap: BOX_GAP, breathe: 0, titleGap: 0, barGap: 1, bandCounts: false };
     case -3:
-      return { mode: 'boxes', scale: 0.55, pad: 0, boxGap: 1, breathe: 0, titleGap: 0, barGap: 1, bandCounts: true };
+      return { mode, scale: 0.55, pad: 0, boxGap: 1, breathe: 0, titleGap: 0, barGap: 1, bandCounts: true };
     case -4:
-      return { mode: 'constellation', scale: 0, pad: 0, boxGap: BOX_GAP, breathe: 0, titleGap: 0, barGap: 1, bandCounts: true };
+      return { mode, scale: 0, pad: 0, boxGap: BOX_GAP, breathe: 0, titleGap: 0, barGap: 1, bandCounts: true };
   }
 }
 
@@ -647,54 +619,6 @@ export function renderMapWindow(map: MellosMap, opts: RenderOptions, viewport: V
   };
 }
 
-/**
- * The derived coarse picture the far zoom renders when the map declares
- * groups: each group becomes ONE labeled node (status derived from members,
- * label carrying done/total), ungrouped nodes stay themselves, and edges
- * collapse onto representatives (intra-group wiring disappears into the
- * box). Derived for rendering only — never persisted. A map without groups
- * returns undefined and falls back to the anonymous glyph constellation.
- */
-function aggregateMap(map: MellosMap): MellosMap | undefined {
-  if (map.groups.length === 0) return undefined;
-  // Group ids join the node-id slug space inside this derived value; the
-  // brands only guard PERSISTED maps, and this one never leaves the renderer.
-  const representative = new Map<string, string>();
-  for (const n of map.nodes) representative.set(n.id as string, (n.group ?? n.id) as string);
-
-  const nodes: MapNode[] = map.groups.map((g) => {
-    const members = map.nodes.filter((n) => n.group === g.id);
-    const done = members.filter((n) => n.status === 'done').length;
-    return {
-      id: g.id as unknown as NodeId,
-      // neutral kinds document structure, not progress — no member counts
-      label: isNeutralKind(map) ? g.label : `${g.label} ${done}/${members.length}`,
-      layer: g.layer,
-      status: groupStatus(map, g.id),
-    };
-  });
-  for (const n of map.nodes) if (n.group === undefined) nodes.push(n);
-
-  const seen = new Set<string>();
-  const edges: DepEdge[] = [];
-  for (const e of map.edges) {
-    const from = representative.get(e.from as string)!;
-    const to = representative.get(e.to as string)!;
-    if (from === to || seen.has(`${from}->${to}`)) continue;
-    seen.add(`${from}->${to}`);
-    edges.push({ from: from as NodeId, to: to as NodeId });
-  }
-  return {
-    ...(map.title !== undefined ? { title: map.title } : {}),
-    ...(map.kind !== undefined ? { kind: map.kind } : {}),
-    layers: map.layers,
-    groups: [],
-    lanes: map.lanes,
-    nodes,
-    edges,
-  };
-}
-
 /** Geometry for the aggregated far zoom: tight chrome, but FULL labels — the point is names. */
 const AGGREGATE_GEO: ZoomGeometry = {
   mode: 'boxes',
@@ -706,24 +630,6 @@ const AGGREGATE_GEO: ZoomGeometry = {
   barGap: 1,
   bandCounts: false,
 };
-
-/**
- * Sequence pages read like the classic diagram: time flows DOWNWARD, the
- * earliest step right under the participant headers. The stored map keeps
- * rank 0 = earliest with edges pointing later -> earlier ("later stands on
- * earlier"); this derived value inverts the ranks and reverses the edges so
- * the unchanged top-down machinery draws top-down time — each wire now runs
- * from the sender's moment down into the receiver's. Derived for rendering
- * only, never persisted (same contract as aggregateMap).
- */
-function flipForSequence(map: MellosMap): MellosMap {
-  if (map.kind !== 'sequence') return map;
-  return {
-    ...map,
-    layers: map.layers.map((l) => ({ ...l, rank: -l.rank })),
-    edges: map.edges.map((e) => ({ from: e.to, to: e.from, ...(e.label !== undefined ? { label: e.label } : {}) })),
-  };
-}
 
 function buildCanvas(map: MellosMap, opts: RenderOptions): { canvas: Canvas; hits: BoxHit[] } {
   const oriented = flipForSequence(map);

--- a/src/semantics/semantics.ts
+++ b/src/semantics/semantics.ts
@@ -10,7 +10,7 @@
  */
 
 import { groupStatus } from '../domain/ops.js';
-import type { DepEdge, MapNode, MellosMap, NodeId } from '../domain/types.js';
+import type { DepEdge, MapGroup, MapNode, MellosMap, NodeId, NodeStatus } from '../domain/types.js';
 
 // ---------------------------------------------------------------------------
 // zoom ladder
@@ -121,6 +121,179 @@ export function aggregateMap(map: MellosMap): MellosMap | undefined {
     nodes,
     edges,
   };
+}
+
+// ---------------------------------------------------------------------------
+// focus semantics — what a detail panel says about a node or group
+// ---------------------------------------------------------------------------
+
+/** One neighbour across a dependency edge, with what flows along it. */
+export interface NeighborRef {
+  readonly id: string;
+  readonly label: string;
+  readonly status: NodeStatus;
+  readonly edgeLabel?: string;
+}
+
+/** Everything a detail panel derives for a focused NODE. */
+export interface NodeFocus {
+  readonly kind: 'node';
+  readonly node: MapNode;
+  readonly layerName: string;
+  readonly laneLabel?: string;
+  /** Lower neighbours this node stands on (on sequence pages: the earlier events). */
+  readonly uses: readonly NeighborRef[];
+  /** Upper neighbours standing on this node (on sequence pages: the later events). */
+  readonly usedBy: readonly NeighborRef[];
+}
+
+/** Everything a detail panel derives for a focused GROUP (the far zoom's boxes). */
+export interface GroupFocus {
+  readonly kind: 'group';
+  readonly group: MapGroup;
+  readonly status: NodeStatus;
+  readonly layerName: string;
+  readonly members: readonly MapNode[];
+  /** Outside-the-group lower neighbours, each shown as its own group when it has one. */
+  readonly uses: readonly NeighborRef[];
+  /** Outside-the-group upper neighbours, each shown as its own group when it has one. */
+  readonly usedBy: readonly NeighborRef[];
+}
+
+/**
+ * Derive what a detail panel says about one focused id — a node, or a group
+ * when the far zoom's aggregated boxes are what the pointer is over. Pure
+ * data: every renderer picks its own glyphs, colors, and words (a sequence
+ * page reads uses/usedBy as after/before; that is the caller's vocabulary).
+ * @param map - the map the focus lives in.
+ * @param focusId - node or group id.
+ * @returns the focus view, or undefined when the id names neither.
+ */
+export function focusInfo(map: MellosMap, focusId: string): NodeFocus | GroupFocus | undefined {
+  const layerNameOf = (layerId: string): string =>
+    map.layers.find((l) => (l.id as string) === layerId)?.name ?? layerId;
+
+  const group = map.groups.find((g) => (g.id as string) === focusId);
+  if (group) {
+    const members = map.nodes.filter((n) => n.group === group.id);
+    const memberIds = new Set(members.map((n) => n.id as string));
+    // A neighbour is shown as its own group when it has one, else as itself.
+    const rep = (id: string): NeighborRef => {
+      const n = map.nodes.find((x) => (x.id as string) === id)!;
+      const owner = n.group !== undefined ? map.groups.find((g) => g.id === n.group) : undefined;
+      return owner !== undefined
+        ? { id: owner.id as string, label: owner.label, status: groupStatus(map, owner.id) }
+        : { id: n.id as string, label: n.label, status: n.status };
+    };
+    const dedupe = (refs: NeighborRef[]): NeighborRef[] => {
+      const seen = new Set<string>();
+      const out: NeighborRef[] = [];
+      for (const r of refs) {
+        if (seen.has(r.id)) continue;
+        seen.add(r.id);
+        out.push(r);
+      }
+      return out;
+    };
+    return {
+      kind: 'group',
+      group,
+      status: groupStatus(map, group.id),
+      layerName: layerNameOf(group.layer as string),
+      members,
+      uses: dedupe(
+        map.edges
+          .filter((e) => memberIds.has(e.from as string) && !memberIds.has(e.to as string))
+          .map((e) => rep(e.to as string)),
+      ),
+      usedBy: dedupe(
+        map.edges
+          .filter((e) => memberIds.has(e.to as string) && !memberIds.has(e.from as string))
+          .map((e) => rep(e.from as string)),
+      ),
+    };
+  }
+
+  const node = map.nodes.find((n) => (n.id as string) === focusId);
+  if (!node) return undefined;
+  const ref = (id: string, edgeLabel: string | undefined): NeighborRef => {
+    const n = map.nodes.find((x) => (x.id as string) === id);
+    return {
+      id,
+      label: n?.label ?? id,
+      status: n?.status ?? 'planned',
+      ...(edgeLabel !== undefined ? { edgeLabel } : {}),
+    };
+  };
+  const laneLabel = node.lane !== undefined ? map.lanes.find((l) => l.id === node.lane)?.label : undefined;
+  return {
+    kind: 'node',
+    node,
+    layerName: layerNameOf(node.layer as string),
+    ...(laneLabel !== undefined ? { laneLabel } : {}),
+    uses: map.edges.filter((e) => e.from === node.id).map((e) => ref(e.to as string, e.label)),
+    usedBy: map.edges.filter((e) => e.to === node.id).map((e) => ref(e.from as string, e.label)),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// page-set semantics — which pages are siblings, and where a dive came from
+// ---------------------------------------------------------------------------
+
+/**
+ * Page slugs some node of any map dives into. A page referenced as a submap
+ * is interior detail — it is reached by diving through its linking node,
+ * never by sitting beside its parent as a sibling tab.
+ * @param maps - every known page's map (undefined entries are skipped).
+ * @returns the referenced submap slugs.
+ */
+export function submapRefs(maps: Iterable<MellosMap | undefined>): Set<string> {
+  const refs = new Set<string>();
+  for (const m of maps) {
+    for (const n of m?.nodes ?? []) if (n.submap !== undefined) refs.add(n.submap as string);
+  }
+  return refs;
+}
+
+/**
+ * Where a sub-map page was dived into from: the entry whose map links the
+ * page, plus the linking node's label. Derived by scan, so a breadcrumb
+ * survives any client restart with an empty dive stack.
+ * @param entries - known pages as (key, map) pairs; keys are caller-owned.
+ * @param pageId - the sub-map page's slug.
+ * @returns the linking entry's key and node label, or undefined for a top-level page.
+ */
+export function diveParent<K>(
+  entries: Iterable<readonly [K, MellosMap | undefined]>,
+  pageId: string,
+): { parent: K; label: string } | undefined {
+  for (const [key, m] of entries) {
+    const node = m?.nodes.find((n) => (n.submap as string | undefined) === pageId);
+    if (node !== undefined) return { parent: key, label: node.label };
+  }
+  return undefined;
+}
+
+/**
+ * The page a client shows when nobody asked for one: the most recently
+ * WRITTEN page — the ledger last touched is almost always the effort under
+ * way. Keys without a readable timestamp lose; an empty set answers the
+ * first key (caller-ordered: default page first, then slug order).
+ * @param keys - candidate page keys in the caller's fallback order.
+ * @param mtimeOf - last-written timestamp of a key, undefined when unknown.
+ * @returns the winning key, or undefined for an empty candidate set.
+ */
+export function mostRecentKey<K>(keys: readonly K[], mtimeOf: (key: K) => number | undefined): K | undefined {
+  let best: K | undefined;
+  let bestMtime = -Infinity;
+  for (const key of keys) {
+    const mtime = mtimeOf(key);
+    if (mtime !== undefined && mtime > bestMtime) {
+      best = key;
+      bestMtime = mtime;
+    }
+  }
+  return best ?? keys[0];
 }
 
 /**

--- a/src/semantics/semantics.ts
+++ b/src/semantics/semantics.ts
@@ -1,0 +1,142 @@
+/**
+ * Layer 1c — medium-neutral VIEW SEMANTICS of a MellosMap.
+ *
+ * Every renderer (the terminal pane, a web panel, a future editor view) must
+ * agree on what a zoom step MEANS, when a map aggregates into its groups,
+ * how sequence time is oriented, and which map kinds render neutrally.
+ * Those rules live here, pure of any medium: no cells, no glyphs, no DOM,
+ * no I/O. Geometry — how a mode maps onto character cells or pixels — stays
+ * private to each renderer.
+ */
+
+import { groupStatus } from '../domain/ops.js';
+import type { DepEdge, MapNode, MellosMap, NodeId } from '../domain/types.js';
+
+// ---------------------------------------------------------------------------
+// zoom ladder
+// ---------------------------------------------------------------------------
+
+/** One wheel tick on the zoom ladder. */
+export type ZoomStep = -4 | -3 | -2 | -1 | 0 | 1 | 2;
+
+export const ZOOM_MIN: ZoomStep = -4;
+export const ZOOM_MAX: ZoomStep = 2;
+export const ZOOM_DEFAULT: ZoomStep = 0;
+
+export function clampZoom(n: number): ZoomStep {
+  return Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, Math.round(n))) as ZoomStep;
+}
+
+/**
+ * What a zoom step MEANS, before any renderer decides what it looks like:
+ * scaling only compresses, the ends of the ladder switch mode. 'detail'
+ * unfolds evidence and design notes; 'overview' switches to the aggregated
+ * far view (groups become the nodes — see aggregateMap); 'boxes' is every
+ * step in between, where boxes stay boxes and only whitespace and label
+ * budgets change.
+ */
+export function zoomMode(zoom: ZoomStep): 'detail' | 'boxes' | 'overview' {
+  if (zoom >= 1) return 'detail';
+  if (zoom <= -4) return 'overview';
+  return 'boxes';
+}
+
+/** What a footer shows: a percentage while scaling, a mode name at the ends. */
+export function zoomLabel(zoom: ZoomStep): string {
+  switch (zoom) {
+    case 2:
+      return 'detail+';
+    case 1:
+      return 'detail';
+    case 0:
+      return '100%';
+    case -1:
+      return '85%';
+    case -2:
+      return '70%';
+    case -3:
+      return '55%';
+    case -4:
+      return 'overview';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// kind semantics
+// ---------------------------------------------------------------------------
+
+/** Documentation kinds render neutrally: no status skins, no progress counts. */
+export function isNeutralKind(map: MellosMap): boolean {
+  return map.kind !== undefined && map.kind !== 'dev';
+}
+
+// ---------------------------------------------------------------------------
+// derived views (never persisted)
+// ---------------------------------------------------------------------------
+
+/**
+ * The derived coarse picture the far zoom renders when the map declares
+ * groups: each group becomes ONE labeled node (status derived from members,
+ * label carrying done/total), ungrouped nodes stay themselves, and edges
+ * collapse onto representatives (intra-group wiring disappears into the
+ * box). Derived for rendering only — never persisted. A map without groups
+ * returns undefined and falls back to whatever anonymous overview the
+ * renderer draws.
+ */
+export function aggregateMap(map: MellosMap): MellosMap | undefined {
+  if (map.groups.length === 0) return undefined;
+  // Group ids join the node-id slug space inside this derived value; the
+  // brands only guard PERSISTED maps, and this one never leaves rendering.
+  const representative = new Map<string, string>();
+  for (const n of map.nodes) representative.set(n.id as string, (n.group ?? n.id) as string);
+
+  const nodes: MapNode[] = map.groups.map((g) => {
+    const members = map.nodes.filter((n) => n.group === g.id);
+    const done = members.filter((n) => n.status === 'done').length;
+    return {
+      id: g.id as unknown as NodeId,
+      // neutral kinds document structure, not progress — no member counts
+      label: isNeutralKind(map) ? g.label : `${g.label} ${done}/${members.length}`,
+      layer: g.layer,
+      status: groupStatus(map, g.id),
+    };
+  });
+  for (const n of map.nodes) if (n.group === undefined) nodes.push(n);
+
+  const seen = new Set<string>();
+  const edges: DepEdge[] = [];
+  for (const e of map.edges) {
+    const from = representative.get(e.from as string)!;
+    const to = representative.get(e.to as string)!;
+    if (from === to || seen.has(`${from}->${to}`)) continue;
+    seen.add(`${from}->${to}`);
+    edges.push({ from: from as NodeId, to: to as NodeId });
+  }
+  return {
+    ...(map.title !== undefined ? { title: map.title } : {}),
+    ...(map.kind !== undefined ? { kind: map.kind } : {}),
+    layers: map.layers,
+    groups: [],
+    lanes: map.lanes,
+    nodes,
+    edges,
+  };
+}
+
+/**
+ * Sequence pages read like the classic diagram: time flows DOWNWARD, the
+ * earliest step right under the participant headers. The stored map keeps
+ * rank 0 = earliest with edges pointing later -> earlier ("later stands on
+ * earlier"); this derived value inverts the ranks and reverses the edges so
+ * unchanged top-down machinery draws top-down time — each wire now runs
+ * from the sender's moment down into the receiver's. Derived for rendering
+ * only, never persisted (same contract as aggregateMap).
+ */
+export function flipForSequence(map: MellosMap): MellosMap {
+  if (map.kind !== 'sequence') return map;
+  return {
+    ...map,
+    layers: map.layers.map((l) => ({ ...l, rank: -l.rank })),
+    edges: map.edges.map((e) => ({ from: e.to, to: e.from, ...(e.label !== undefined ? { label: e.label } : {}) })),
+  };
+}

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -23,7 +23,7 @@ let stateFile: string;
 
 beforeEach(async () => {
   dir = mkdtempSync(join(tmpdir(), 'mellos-mapping-server-'));
-  stateFile = join(dir, '.claude', 'mellos-mapping.json');
+  stateFile = join(dir, '.mellos', 'map.json');
   const server = buildServer(stateFile);
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   client = new Client({ name: 'spec-client', version: '0.0.0' });
@@ -123,7 +123,7 @@ describe('mellos-mapping MCP server', () => {
     expect(paged.text).toContain('[page: pages-feature]');
 
     // the page landed in its own file; the default page is untouched
-    const pageFile = join(dir, '.claude', 'mellos-mapping.pages', 'pages-feature.json');
+    const pageFile = join(dir, '.mellos', 'pages', 'pages-feature.json');
     expect((JSON.parse(readFileSync(pageFile, 'utf8')) as { title: string }).title).toBe('多页支持');
     expect(readFileSync(stateFile, 'utf8')).toBe(defaultBefore);
 
@@ -168,7 +168,7 @@ describe('mapping policy setup — the flow enforces itself over the wire', () =
     const set = await callText('mmap_setup', { policy: 'complex' });
     expect(set.isError).toBe(false);
     expect(set.text).toContain('mapping policy set: complex');
-    const configFile = join(dir, '.claude', 'mellos-mapping.config.json');
+    const configFile = join(dir, '.mellos', 'config.json');
     expect(JSON.parse(readFileSync(configFile, 'utf8'))).toEqual({ version: 1, policy: 'complex' });
 
     const second = await callText('mmap_declare', { nodes: [{ id: 'more', label: 'More', layer: 'base' }] });
@@ -193,7 +193,7 @@ describe('mapping policy setup — the flow enforces itself over the wire', () =
   });
 
   it('a broken config file is surfaced on declare and on read, never treated as unset', async () => {
-    const configFile = join(dir, '.claude', 'mellos-mapping.config.json');
+    const configFile = join(dir, '.mellos', 'config.json');
     await callText('mmap_declare', DECLARE); // creates .claude/
     writeFileSync(configFile, 'not json');
 
@@ -212,11 +212,11 @@ describe('resolveStateFile', () => {
   it('resolves MELLOS_MAPPING_CWD, then CLAUDE_PROJECT_DIR, then the process cwd', () => {
     expect(
       resolveStateFile({ MELLOS_MAPPING_CWD: 'D:\\override', CLAUDE_PROJECT_DIR: 'D:\\proj' }, 'C:\\elsewhere'),
-    ).toBe(join('D:\\override', '.claude', 'mellos-mapping.json'));
+    ).toBe(join('D:\\override', '.mellos', 'map.json'));
     expect(resolveStateFile({ CLAUDE_PROJECT_DIR: 'D:\\proj' }, 'C:\\elsewhere')).toBe(
-      join('D:\\proj', '.claude', 'mellos-mapping.json'),
+      join('D:\\proj', '.mellos', 'map.json'),
     );
-    expect(resolveStateFile({}, 'C:\\elsewhere')).toBe(join('C:\\elsewhere', '.claude', 'mellos-mapping.json'));
+    expect(resolveStateFile({}, 'C:\\elsewhere')).toBe(join('C:\\elsewhere', '.mellos', 'map.json'));
   });
 });
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -36,6 +36,7 @@ import {
   configFilePath,
   describeMappingPolicy,
   describeStoreError,
+  migrateLegacyStore,
   loadMapFile,
   loadMappingPolicy,
   pageFilePath,
@@ -357,7 +358,10 @@ export function resolveStateFile(env: NodeJS.ProcessEnv, cwd: string): string {
 }
 
 async function main(): Promise<void> {
-  const server = buildServer(resolveStateFile(process.env, process.cwd()));
+  const stateFile = resolveStateFile(process.env, process.cwd());
+  // One-time move of a pre-0.19 `.claude` store into `.mellos` (store.ts).
+  migrateLegacyStore(stateFile);
+  const server = buildServer(stateFile);
   await server.connect(new StdioServerTransport());
 }
 

--- a/src/store/format.ts
+++ b/src/store/format.ts
@@ -1,0 +1,230 @@
+/**
+ * Layer 1a — the state-file FORMAT of a MellosMap, pure of any I/O.
+ *
+ * This module owns the on-disk vocabulary (version, page-id grammar) and the
+ * two format promises every consumer relies on:
+ *
+ *   P1. Whatever parseMap accepts satisfies the structural invariants of
+ *       Layer 0. Parsing is done by REPLAYING the raw data through the domain
+ *       operations, so a hand-edited or corrupted file can never smuggle an
+ *       invariant violation into the process (validate at the boundary,
+ *       trust internal code afterwards).
+ *   F1. serializeMap is the inverse of parseMap for valid maps.
+ *
+ * No node:* imports — this module must load in a browser as-is. Filesystem
+ * concerns (atomic writes, page file listing, focus requests) live in
+ * ./store.ts, the Node-side half.
+ */
+
+import { declareGroup, declareLane, declareLayer, declareNode, linkNodes, setKind, setTitle, updateNode } from '../domain/ops.js';
+import {
+  EMPTY_MAP,
+  ID_RULE,
+  ID_RULE_TEXT,
+  type InvalidId,
+  type MapError,
+  type MellosMap,
+  type Result,
+  describeMapError,
+  err,
+  makeGroupId,
+  makeLaneId,
+  makeLayerId,
+  makeMapKind,
+  makeNodeId,
+  makeNodeKind,
+  makeNodeStatus,
+  makeSubmapRef,
+  ok,
+} from '../domain/types.js';
+
+/** On-disk format version. Bump only with a documented migration. */
+export const STATE_FILE_VERSION = 1;
+
+export type PageId = string & { readonly __brand: 'PageId' };
+
+export function makePageId(raw: string): Result<PageId, InvalidId> {
+  return ID_RULE.test(raw) ? ok(raw as PageId) : err({ kind: 'invalid-id', raw, rule: ID_RULE_TEXT });
+}
+
+export type StoreError =
+  | { readonly kind: 'not-found'; readonly path: string }
+  | { readonly kind: 'malformed-json'; readonly path: string; readonly detail: string }
+  | { readonly kind: 'bad-shape'; readonly path: string; readonly detail: string }
+  | { readonly kind: 'invariant-violation'; readonly path: string; readonly violation: MapError };
+
+export function describeStoreError(e: StoreError): string {
+  switch (e.kind) {
+    case 'not-found':
+      return `no map file at ${e.path}`;
+    case 'malformed-json':
+      return `map file ${e.path} is not valid JSON: ${e.detail}`;
+    case 'bad-shape':
+      return `map file ${e.path} has an unexpected shape: ${e.detail}`;
+    case 'invariant-violation':
+      return `map file ${e.path} violates a structural invariant: ${describeMapError(e.violation)}`;
+  }
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function asArray(v: unknown): readonly unknown[] {
+  return Array.isArray(v) ? v : [];
+}
+
+function optionalString(v: unknown): string | undefined {
+  return typeof v === 'string' ? v : undefined;
+}
+
+/**
+ * Rebuild a MellosMap from untrusted raw data by replaying it through the
+ * Layer 0 operations (P1). Field order in the file does not matter; replay
+ * order (layers -> lanes -> groups -> nodes -> edges) supplies the required
+ * declaration order.
+ */
+export function parseMap(raw: unknown, path: string): Result<MellosMap, StoreError> {
+  if (!isRecord(raw)) return err({ kind: 'bad-shape', path, detail: 'root is not an object' });
+  if (raw['version'] !== STATE_FILE_VERSION) {
+    return err({ kind: 'bad-shape', path, detail: `version is ${String(raw['version'])}, expected ${STATE_FILE_VERSION}` });
+  }
+
+  let map = EMPTY_MAP;
+  const title = optionalString(raw['title']);
+  if (title !== undefined) map = setTitle(map, title);
+  const rawKind = optionalString(raw['kind']);
+  if (rawKind !== undefined) {
+    const kind = makeMapKind(rawKind);
+    if (!kind.ok) return err({ kind: 'invariant-violation', path, violation: kind.error });
+    map = setKind(map, kind.value);
+  }
+
+  for (const [i, rawLayer] of asArray(raw['layers']).entries()) {
+    if (!isRecord(rawLayer)) return err({ kind: 'bad-shape', path, detail: `layers[${i}] is not an object` });
+    const id = makeLayerId(String(rawLayer['id'] ?? ''));
+    if (!id.ok) return err({ kind: 'invariant-violation', path, violation: id.error });
+    const name = optionalString(rawLayer['name']);
+    const rank = rawLayer['rank'];
+    if (name === undefined || typeof rank !== 'number' || !Number.isInteger(rank)) {
+      return err({ kind: 'bad-shape', path, detail: `layers[${i}] needs a string name and an integer rank` });
+    }
+    const next = declareLayer(map, { id: id.value, name, rank });
+    if (!next.ok) return err({ kind: 'invariant-violation', path, violation: next.error });
+    map = next.value;
+  }
+
+  for (const [i, rawLane] of asArray(raw['lanes']).entries()) {
+    if (!isRecord(rawLane)) return err({ kind: 'bad-shape', path, detail: `lanes[${i}] is not an object` });
+    const id = makeLaneId(String(rawLane['id'] ?? ''));
+    if (!id.ok) return err({ kind: 'invariant-violation', path, violation: id.error });
+    const label = optionalString(rawLane['label']);
+    if (label === undefined) return err({ kind: 'bad-shape', path, detail: `lanes[${i}] needs a string label` });
+    const declared = declareLane(map, { id: id.value, label });
+    if (!declared.ok) return err({ kind: 'invariant-violation', path, violation: declared.error });
+    map = declared.value;
+  }
+
+  for (const [i, rawGroup] of asArray(raw['groups']).entries()) {
+    if (!isRecord(rawGroup)) return err({ kind: 'bad-shape', path, detail: `groups[${i}] is not an object` });
+    const id = makeGroupId(String(rawGroup['id'] ?? ''));
+    if (!id.ok) return err({ kind: 'invariant-violation', path, violation: id.error });
+    const layer = makeLayerId(String(rawGroup['layer'] ?? ''));
+    if (!layer.ok) return err({ kind: 'invariant-violation', path, violation: layer.error });
+    const label = optionalString(rawGroup['label']);
+    if (label === undefined) return err({ kind: 'bad-shape', path, detail: `groups[${i}] needs a string label` });
+    const declared = declareGroup(map, { id: id.value, label, layer: layer.value });
+    if (!declared.ok) return err({ kind: 'invariant-violation', path, violation: declared.error });
+    map = declared.value;
+  }
+
+  for (const [i, rawNode] of asArray(raw['nodes']).entries()) {
+    if (!isRecord(rawNode)) return err({ kind: 'bad-shape', path, detail: `nodes[${i}] is not an object` });
+    const id = makeNodeId(String(rawNode['id'] ?? ''));
+    if (!id.ok) return err({ kind: 'invariant-violation', path, violation: id.error });
+    const layer = makeLayerId(String(rawNode['layer'] ?? ''));
+    if (!layer.ok) return err({ kind: 'invariant-violation', path, violation: layer.error });
+    const status = makeNodeStatus(String(rawNode['status'] ?? ''));
+    if (!status.ok) return err({ kind: 'invariant-violation', path, violation: status.error });
+    const label = optionalString(rawNode['label']);
+    if (label === undefined) return err({ kind: 'bad-shape', path, detail: `nodes[${i}] needs a string label` });
+
+    const detail = optionalString(rawNode['detail']);
+    const rawGroup = optionalString(rawNode['group']);
+    let group;
+    if (rawGroup !== undefined) {
+      const made = makeGroupId(rawGroup);
+      if (!made.ok) return err({ kind: 'invariant-violation', path, violation: made.error });
+      group = made.value;
+    }
+    const rawNodeKind = optionalString(rawNode['kind']);
+    let nodeKind;
+    if (rawNodeKind !== undefined) {
+      const made = makeNodeKind(rawNodeKind);
+      if (!made.ok) return err({ kind: 'invariant-violation', path, violation: made.error });
+      nodeKind = made.value;
+    }
+    const rawLane = optionalString(rawNode['lane']);
+    let lane;
+    if (rawLane !== undefined) {
+      const made = makeLaneId(rawLane);
+      if (!made.ok) return err({ kind: 'invariant-violation', path, violation: made.error });
+      lane = made.value;
+    }
+    const rawSubmap = optionalString(rawNode['submap']);
+    let submap;
+    if (rawSubmap !== undefined) {
+      const made = makeSubmapRef(rawSubmap);
+      if (!made.ok) return err({ kind: 'invariant-violation', path, violation: made.error });
+      submap = made.value;
+    }
+    const declared = declareNode(map, {
+      id: id.value,
+      label,
+      layer: layer.value,
+      status: status.value,
+      ...(detail !== undefined ? { detail } : {}),
+      ...(group !== undefined ? { group } : {}),
+      ...(nodeKind !== undefined ? { kind: nodeKind } : {}),
+      ...(lane !== undefined ? { lane } : {}),
+      ...(submap !== undefined ? { submap } : {}),
+    });
+    if (!declared.ok) return err({ kind: 'invariant-violation', path, violation: declared.error });
+    map = declared.value;
+
+    const evidence = optionalString(rawNode['evidence']);
+    if (evidence !== undefined) {
+      const updated = updateNode(map, { id: id.value, evidence });
+      if (!updated.ok) return err({ kind: 'invariant-violation', path, violation: updated.error });
+      map = updated.value;
+    }
+  }
+
+  for (const [i, rawEdge] of asArray(raw['edges']).entries()) {
+    if (!isRecord(rawEdge)) return err({ kind: 'bad-shape', path, detail: `edges[${i}] is not an object` });
+    const from = makeNodeId(String(rawEdge['from'] ?? ''));
+    if (!from.ok) return err({ kind: 'invariant-violation', path, violation: from.error });
+    const to = makeNodeId(String(rawEdge['to'] ?? ''));
+    if (!to.ok) return err({ kind: 'invariant-violation', path, violation: to.error });
+    const linked = linkNodes(map, from.value, to.value, optionalString(rawEdge['label']));
+    if (!linked.ok) return err({ kind: 'invariant-violation', path, violation: linked.error });
+    map = linked.value;
+  }
+
+  return ok(map);
+}
+
+/** Serialize a map into the on-disk shape. Inverse of parseMap for valid maps (F1). */
+export function serializeMap(map: MellosMap): string {
+  const body = {
+    version: STATE_FILE_VERSION,
+    ...(map.title !== undefined ? { title: map.title } : {}),
+    ...(map.kind !== undefined ? { kind: map.kind } : {}),
+    layers: map.layers,
+    ...(map.lanes.length > 0 ? { lanes: map.lanes } : {}),
+    ...(map.groups.length > 0 ? { groups: map.groups } : {}),
+    nodes: map.nodes,
+    edges: map.edges,
+  };
+  return JSON.stringify(body, null, 2) + '\n';
+}

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -22,6 +22,7 @@ import {
   type SubmapRef,
 } from '../domain/types.js';
 import {
+  STATE_FILE_RELATIVE_PATH,
   configFilePath,
   describeMappingPolicy,
   focusFilePath,
@@ -30,6 +31,7 @@ import {
   loadMappingPolicy,
   makeMappingPolicy,
   makePageId,
+  migrateLegacyStore,
   pageFilePath,
   pageIdOfFile,
   parseMap,
@@ -86,15 +88,15 @@ afterEach(() => {
 
 describe('round-trip (P1 + P2)', () => {
   it('save then load reproduces the map exactly', () => {
-    const path = join(dir, '.claude', 'mellos-mapping.json');
+    const path = join(dir, '.mellos', 'map.json');
     saveMapFile(path, sampleMap());
     expect(must(loadMapFile(path))).toEqual(sampleMap());
   });
 
   it('creates the parent directory and leaves no temp file behind', () => {
-    const path = join(dir, '.claude', 'mellos-mapping.json');
+    const path = join(dir, '.mellos', 'map.json');
     saveMapFile(path, sampleMap());
-    expect(readdirSync(join(dir, '.claude'))).toEqual(['mellos-mapping.json']);
+    expect(readdirSync(join(dir, '.mellos'))).toEqual(['map.json']);
   });
 
   it('serializes deterministically', () => {
@@ -226,17 +228,17 @@ describe('pages — one effort, one file', () => {
   });
 
   it('maps the default page to the classic file and named pages to the pages dir', () => {
-    const defaultFile = join(dir, '.claude', 'mellos-mapping.json');
+    const defaultFile = join(dir, '.mellos', 'map.json');
     expect(pageFilePath(defaultFile)).toBe(defaultFile);
     const named = pageFilePath(defaultFile, must(makePageId('pages')));
-    expect(named).toBe(join(dir, '.claude', 'mellos-mapping.pages', 'pages.json'));
+    expect(named).toBe(join(dir, '.mellos', 'pages', 'pages.json'));
     // path -> id roundtrip
     expect(pageIdOfFile(defaultFile, defaultFile)).toBeUndefined();
     expect(pageIdOfFile(defaultFile, named)).toBe('pages');
   });
 
   it('lists existing pages: default first, then named pages sorted by slug', () => {
-    const defaultFile = join(dir, '.claude', 'mellos-mapping.json');
+    const defaultFile = join(dir, '.mellos', 'map.json');
     expect(listPageFiles(defaultFile)).toEqual([]); // nothing yet
     saveMapFile(pageFilePath(defaultFile, must(makePageId('zeta'))), sampleMap());
     saveMapFile(pageFilePath(defaultFile, must(makePageId('alpha'))), sampleMap());
@@ -250,16 +252,16 @@ describe('pages — one effort, one file', () => {
 
 describe('focus requests — one-shot "show this page" channel', () => {
   it('the focus file sits beside the default file', () => {
-    const defaultFile = join(dir, 'mellos-mapping.json');
-    expect(focusFilePath(defaultFile)).toBe(join(dir, 'mellos-mapping.focus'));
+    const defaultFile = join(dir, 'map.json');
+    expect(focusFilePath(defaultFile)).toBe(join(dir, 'focus'));
   });
 
   it('no file means no request', () => {
-    expect(takeFocusRequest(join(dir, 'mellos-mapping.json'))).toBeUndefined();
+    expect(takeFocusRequest(join(dir, 'map.json'))).toBeUndefined();
   });
 
   it('consuming a request returns the page AND deletes the file (one-shot)', () => {
-    const defaultFile = join(dir, 'mellos-mapping.json');
+    const defaultFile = join(dir, 'map.json');
     writeFileSync(focusFilePath(defaultFile), '{"page":"page-focus"}');
     expect(takeFocusRequest(defaultFile)).toEqual({ page: 'page-focus' });
     expect(existsSync(focusFilePath(defaultFile))).toBe(false);
@@ -267,7 +269,7 @@ describe('focus requests — one-shot "show this page" channel', () => {
   });
 
   it('page null (or absent) requests the default page', () => {
-    const defaultFile = join(dir, 'mellos-mapping.json');
+    const defaultFile = join(dir, 'map.json');
     writeFileSync(focusFilePath(defaultFile), '{"page":null}');
     expect(takeFocusRequest(defaultFile)).toEqual({ page: undefined });
     writeFileSync(focusFilePath(defaultFile), '{}');
@@ -275,7 +277,7 @@ describe('focus requests — one-shot "show this page" channel', () => {
   });
 
   it('junk in the channel is no request, and the delete sweeps it', () => {
-    const defaultFile = join(dir, 'mellos-mapping.json');
+    const defaultFile = join(dir, 'map.json');
     for (const junk of ['not json', '"just-a-string"', '{"page":5}', '{"page":"NOT A SLUG"}']) {
       writeFileSync(focusFilePath(defaultFile), junk);
       expect(takeFocusRequest(defaultFile)).toBeUndefined();
@@ -287,7 +289,7 @@ describe('focus requests — one-shot "show this page" channel', () => {
 describe('mapping policy — project setup choice', () => {
   it('the config file sits beside the default file', () => {
     const defaultFile = join(dir, 'mellos-mapping.json');
-    expect(configFilePath(defaultFile)).toBe(join(dir, 'mellos-mapping.config.json'));
+    expect(configFilePath(defaultFile)).toBe(join(dir, 'config.json'));
   });
 
   it('validates the policy value at the boundary', () => {
@@ -301,7 +303,7 @@ describe('mapping policy — project setup choice', () => {
     const defaultFile = join(dir, 'mellos-mapping.json');
     saveMappingPolicy(defaultFile, 'on-request');
     expect(loadMappingPolicy(defaultFile)).toEqual({ ok: true, value: 'on-request' });
-    expect(readdirSync(dir)).toEqual(['mellos-mapping.config.json']);
+    expect(readdirSync(dir)).toEqual(['config.json']);
     saveMappingPolicy(defaultFile, 'always'); // a re-run of setup overwrites
     expect(loadMappingPolicy(defaultFile)).toEqual({ ok: true, value: 'always' });
   });
@@ -349,5 +351,33 @@ describe('atomicity (P2)', () => {
     expect(after).toBe(serializeMap(next));
     expect(after).not.toBe(before);
     expect(readdirSync(dir)).toEqual(['map.json']);
+  });
+});
+
+describe('legacy store migration (.claude -> .mellos)', () => {
+  it('moves a legacy store once, pages included', () => {
+    const legacyDefault = join(dir, '.claude', 'mellos-mapping.json');
+    saveMapFile(legacyDefault, sampleMap());
+    saveMapFile(join(dir, '.claude', 'mellos-mapping.pages', 'side.json'), sampleMap());
+    const defaultFile = join(dir, STATE_FILE_RELATIVE_PATH);
+    expect(migrateLegacyStore(defaultFile)).toBe(true);
+    expect(must(loadMapFile(defaultFile))).toEqual(sampleMap());
+    expect(listPageFiles(defaultFile).map((p) => pageIdOfFile(defaultFile, p))).toEqual([undefined, 'side']);
+    expect(existsSync(legacyDefault)).toBe(false);
+    // Second call is a no-op: the move happens exactly once.
+    expect(migrateLegacyStore(defaultFile)).toBe(false);
+  });
+
+  it('never merges into a project whose new store already holds anything', () => {
+    const defaultFile = join(dir, STATE_FILE_RELATIVE_PATH);
+    saveMapFile(defaultFile, sampleMap());
+    const legacyDefault = join(dir, '.claude', 'mellos-mapping.json');
+    saveMapFile(legacyDefault, sampleMap());
+    expect(migrateLegacyStore(defaultFile)).toBe(false);
+    expect(existsSync(legacyDefault)).toBe(true);
+  });
+
+  it('a project with no store anywhere is a no-op', () => {
+    expect(migrateLegacyStore(join(dir, STATE_FILE_RELATIVE_PATH))).toBe(false);
   });
 });

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -35,20 +35,26 @@ export {
   serializeMap,
 } from './format.js';
 
-/** Project-relative location of the DEFAULT page's state file. */
-export const STATE_FILE_RELATIVE_PATH = join('.claude', 'mellos-mapping.json');
+/**
+ * Project-relative location of the DEFAULT page's state file. The store lives
+ * in the tool-owned `.mellos/` directory: the map belongs to mellos-mapping,
+ * not to whichever host (Claude Code, Codex, a harness) happens to drive the
+ * server, so no host brand appears in the path. Pre-0.19 stores under
+ * `.claude/` are moved once by {@link migrateLegacyStore}.
+ */
+export const STATE_FILE_RELATIVE_PATH = join('.mellos', 'map.json');
 
 // ---------------------------------------------------------------------------
 // pages — a project may keep several maps side by side (one effort = one page)
 // ---------------------------------------------------------------------------
 //
-// The default page IS the classic mellos-mapping.json, so existing maps stay
-// where they are. Named pages live in a sibling directory, one file each:
-// file-per-page keeps concurrent sessions isolated — two writers on two pages
-// can never clobber each other, because every save renames a whole file.
+// The default page IS the classic map.json. Named pages live in a sibling
+// directory, one file each: file-per-page keeps concurrent sessions isolated —
+// two writers on two pages can never clobber each other, because every save
+// renames a whole file.
 
 /** Directory (next to the default file) holding the named pages. */
-export const PAGES_DIR_NAME = 'mellos-mapping.pages';
+export const PAGES_DIR_NAME = 'pages';
 
 /** Where a page's map file lives, given the default page's file path. */
 export function pageFilePath(defaultFile: string, page?: PageId): string {
@@ -90,7 +96,7 @@ export function listPageFiles(defaultFile: string): string[] {
 // status barely ever sees the file exist.
 
 /** Sibling of the default file carrying a one-shot "show this page" request. */
-export const FOCUS_FILE_NAME = 'mellos-mapping.focus';
+export const FOCUS_FILE_NAME = 'focus';
 
 export function focusFilePath(defaultFile: string): string {
   return join(dirname(defaultFile), FOCUS_FILE_NAME);
@@ -144,7 +150,7 @@ export function takeFocusRequest(defaultFile: string): FocusRequest | undefined 
 // sibling file so hand-editing or corrupting it can never touch a map.
 
 /** Sibling of the default file holding the project's plugin configuration. */
-export const CONFIG_FILE_NAME = 'mellos-mapping.config.json';
+export const CONFIG_FILE_NAME = 'config.json';
 
 /** On-disk config format version. Bump only with a documented migration. */
 export const CONFIG_FILE_VERSION = 1;
@@ -227,6 +233,48 @@ export function saveMappingPolicy(defaultFile: string, policy: MappingPolicy): v
   writeFileSync(tmp, JSON.stringify({ version: CONFIG_FILE_VERSION, policy }, null, 2) + '\n', 'utf8');
   renameSync(tmp, path);
 }
+
+// ---------------------------------------------------------------------------
+// legacy migration — stores written under the old host-coupled location
+// ---------------------------------------------------------------------------
+//
+// Up to 0.18 the store lived in `.claude/mellos-mapping.*`: the map's home
+// was coupled to one host brand, which turned absurd the moment another host
+// (a harness, Codex) drove the same server. The move is one-time and
+// explicit — entry points call it before touching the store; nothing here
+// runs as a hidden side effect of ordinary loads.
+
+/** Project-relative location of the pre-0.20 default page file. */
+export const LEGACY_STATE_FILE_RELATIVE_PATH = join('.claude', 'mellos-mapping.json');
+const LEGACY_PAGES_DIR_NAME = 'mellos-mapping.pages';
+const LEGACY_CONFIG_FILE_NAME = 'mellos-mapping.config.json';
+
+/**
+ * Move a legacy `.claude` store — map, pages, and mapping-policy config —
+ * into the tool-owned `.mellos` location. Never merges: a project whose new
+ * store already holds anything keeps it untouched, whatever the legacy
+ * directory still contains.
+ * @param defaultFile - the NEW default page path (`<root>/.mellos/map.json`);
+ *   the legacy store is looked up relative to `<root>`.
+ * @returns whether a legacy store was moved.
+ */
+export function migrateLegacyStore(defaultFile: string): boolean {
+  const projectRoot = dirname(dirname(defaultFile));
+  const legacyDefault = join(projectRoot, LEGACY_STATE_FILE_RELATIVE_PATH);
+  const legacyPages = join(dirname(legacyDefault), LEGACY_PAGES_DIR_NAME);
+  const legacyConfig = join(dirname(legacyDefault), LEGACY_CONFIG_FILE_NAME);
+  const hasLegacy = existsSync(legacyDefault) || existsSync(legacyPages) || existsSync(legacyConfig);
+  const hasCurrent = existsSync(defaultFile)
+    || existsSync(join(dirname(defaultFile), PAGES_DIR_NAME))
+    || existsSync(configFilePath(defaultFile));
+  if (!hasLegacy || hasCurrent) return false;
+  mkdirSync(dirname(defaultFile), { recursive: true });
+  if (existsSync(legacyDefault)) renameSync(legacyDefault, defaultFile);
+  if (existsSync(legacyPages)) renameSync(legacyPages, join(dirname(defaultFile), PAGES_DIR_NAME));
+  if (existsSync(legacyConfig)) renameSync(legacyConfig, configFilePath(defaultFile));
+  return true;
+}
+
 /** Load and validate the map file at `path`. */
 export function loadMapFile(path: string): Result<MellosMap, StoreError> {
   let text: string;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,14 +1,12 @@
 /**
- * Layer 1 — persistence for a MellosMap.
+ * Layer 1b — Node-side persistence for a MellosMap.
  *
  * The state file IS the event bus of the whole plugin: the MCP server writes
- * it, the terminal watcher polls it. This layer owns exactly two promises:
+ * it, the terminal watcher polls it. The file FORMAT (version, page-id
+ * grammar, parse/serialize with boundary validation) lives in ./format.ts,
+ * pure of I/O so browsers can consume it; this module owns everything that
+ * touches the filesystem, and one promise:
  *
- *   P1. Whatever is loaded satisfies the structural invariants of Layer 0.
- *       Parsing is done by REPLAYING the raw data through the domain
- *       operations, so a hand-edited or corrupted file can never smuggle an
- *       invariant violation into the process (validate at the boundary,
- *       trust internal code afterwards).
  *   P2. Writes are atomic: a reader polling the file either sees the previous
  *       complete map or the new complete map, never a torn write. Achieved by
  *       writing a sibling temp file and renaming it over the target.
@@ -16,35 +14,26 @@
  * Expected failures (missing file, malformed JSON, invariant violations) are
  * Result values. Only truly unexpected I/O faults (permissions, disk) are
  * allowed to propagate as exceptions.
+ *
+ * Node consumers import everything from here; the format surface is
+ * re-exported so persistence has one import site per runtime.
  */
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 
-import { declareGroup, declareLane, declareLayer, declareNode, linkNodes, setKind, setTitle, updateNode } from '../domain/ops.js';
-import {
-  EMPTY_MAP,
-  ID_RULE,
-  ID_RULE_TEXT,
-  type InvalidId,
-  type MapError,
-  type MellosMap,
-  type Result,
-  describeMapError,
-  err,
-  makeGroupId,
-  makeLaneId,
-  makeLayerId,
-  makeMapKind,
-  makeNodeId,
-  makeNodeKind,
-  makeNodeStatus,
-  makeSubmapRef,
-  ok,
-} from '../domain/types.js';
+import { type MellosMap, type Result, err, ok } from '../domain/types.js';
+import { type PageId, type StoreError, makePageId, parseMap, serializeMap } from './format.js';
 
-/** On-disk format version. Bump only with a documented migration. */
-export const STATE_FILE_VERSION = 1;
+export {
+  STATE_FILE_VERSION,
+  type PageId,
+  makePageId,
+  type StoreError,
+  describeStoreError,
+  parseMap,
+  serializeMap,
+} from './format.js';
 
 /** Project-relative location of the DEFAULT page's state file. */
 export const STATE_FILE_RELATIVE_PATH = join('.claude', 'mellos-mapping.json');
@@ -60,12 +49,6 @@ export const STATE_FILE_RELATIVE_PATH = join('.claude', 'mellos-mapping.json');
 
 /** Directory (next to the default file) holding the named pages. */
 export const PAGES_DIR_NAME = 'mellos-mapping.pages';
-
-export type PageId = string & { readonly __brand: 'PageId' };
-
-export function makePageId(raw: string): Result<PageId, InvalidId> {
-  return ID_RULE.test(raw) ? ok(raw as PageId) : err({ kind: 'invalid-id', raw, rule: ID_RULE_TEXT });
-}
 
 /** Where a page's map file lives, given the default page's file path. */
 export function pageFilePath(defaultFile: string, page?: PageId): string {
@@ -151,6 +134,7 @@ export function takeFocusRequest(defaultFile: string): FocusRequest | undefined 
   return id.ok ? { page: id.value } : undefined;
 }
 
+
 // ---------------------------------------------------------------------------
 // mapping policy — WHEN the assistant should open a map, chosen by the user
 // ---------------------------------------------------------------------------
@@ -198,6 +182,10 @@ export function describeMappingPolicy(policy: MappingPolicy): string {
   }
 }
 
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
 /**
  * The configured policy, or ok(undefined) when the project has never been
  * set up (missing file or missing key — both mean "nobody chose yet").
@@ -239,189 +227,6 @@ export function saveMappingPolicy(defaultFile: string, policy: MappingPolicy): v
   writeFileSync(tmp, JSON.stringify({ version: CONFIG_FILE_VERSION, policy }, null, 2) + '\n', 'utf8');
   renameSync(tmp, path);
 }
-
-export type StoreError =
-  | { readonly kind: 'not-found'; readonly path: string }
-  | { readonly kind: 'malformed-json'; readonly path: string; readonly detail: string }
-  | { readonly kind: 'bad-shape'; readonly path: string; readonly detail: string }
-  | { readonly kind: 'invariant-violation'; readonly path: string; readonly violation: MapError };
-
-export function describeStoreError(e: StoreError): string {
-  switch (e.kind) {
-    case 'not-found':
-      return `no map file at ${e.path}`;
-    case 'malformed-json':
-      return `map file ${e.path} is not valid JSON: ${e.detail}`;
-    case 'bad-shape':
-      return `map file ${e.path} has an unexpected shape: ${e.detail}`;
-    case 'invariant-violation':
-      return `map file ${e.path} violates a structural invariant: ${describeMapError(e.violation)}`;
-  }
-}
-
-function isRecord(v: unknown): v is Record<string, unknown> {
-  return typeof v === 'object' && v !== null && !Array.isArray(v);
-}
-
-function asArray(v: unknown): readonly unknown[] {
-  return Array.isArray(v) ? v : [];
-}
-
-function optionalString(v: unknown): string | undefined {
-  return typeof v === 'string' ? v : undefined;
-}
-
-/**
- * Rebuild a MellosMap from untrusted raw data by replaying it through the
- * Layer 0 operations (P1). Field order in the file does not matter; replay
- * order (layers -> lanes -> groups -> nodes -> edges) supplies the required
- * declaration order.
- */
-export function parseMap(raw: unknown, path: string): Result<MellosMap, StoreError> {
-  if (!isRecord(raw)) return err({ kind: 'bad-shape', path, detail: 'root is not an object' });
-  if (raw['version'] !== STATE_FILE_VERSION) {
-    return err({ kind: 'bad-shape', path, detail: `version is ${String(raw['version'])}, expected ${STATE_FILE_VERSION}` });
-  }
-
-  let map = EMPTY_MAP;
-  const title = optionalString(raw['title']);
-  if (title !== undefined) map = setTitle(map, title);
-  const rawKind = optionalString(raw['kind']);
-  if (rawKind !== undefined) {
-    const kind = makeMapKind(rawKind);
-    if (!kind.ok) return err({ kind: 'invariant-violation', path, violation: kind.error });
-    map = setKind(map, kind.value);
-  }
-
-  for (const [i, rawLayer] of asArray(raw['layers']).entries()) {
-    if (!isRecord(rawLayer)) return err({ kind: 'bad-shape', path, detail: `layers[${i}] is not an object` });
-    const id = makeLayerId(String(rawLayer['id'] ?? ''));
-    if (!id.ok) return err({ kind: 'invariant-violation', path, violation: id.error });
-    const name = optionalString(rawLayer['name']);
-    const rank = rawLayer['rank'];
-    if (name === undefined || typeof rank !== 'number' || !Number.isInteger(rank)) {
-      return err({ kind: 'bad-shape', path, detail: `layers[${i}] needs a string name and an integer rank` });
-    }
-    const next = declareLayer(map, { id: id.value, name, rank });
-    if (!next.ok) return err({ kind: 'invariant-violation', path, violation: next.error });
-    map = next.value;
-  }
-
-  for (const [i, rawLane] of asArray(raw['lanes']).entries()) {
-    if (!isRecord(rawLane)) return err({ kind: 'bad-shape', path, detail: `lanes[${i}] is not an object` });
-    const id = makeLaneId(String(rawLane['id'] ?? ''));
-    if (!id.ok) return err({ kind: 'invariant-violation', path, violation: id.error });
-    const label = optionalString(rawLane['label']);
-    if (label === undefined) return err({ kind: 'bad-shape', path, detail: `lanes[${i}] needs a string label` });
-    const declared = declareLane(map, { id: id.value, label });
-    if (!declared.ok) return err({ kind: 'invariant-violation', path, violation: declared.error });
-    map = declared.value;
-  }
-
-  for (const [i, rawGroup] of asArray(raw['groups']).entries()) {
-    if (!isRecord(rawGroup)) return err({ kind: 'bad-shape', path, detail: `groups[${i}] is not an object` });
-    const id = makeGroupId(String(rawGroup['id'] ?? ''));
-    if (!id.ok) return err({ kind: 'invariant-violation', path, violation: id.error });
-    const layer = makeLayerId(String(rawGroup['layer'] ?? ''));
-    if (!layer.ok) return err({ kind: 'invariant-violation', path, violation: layer.error });
-    const label = optionalString(rawGroup['label']);
-    if (label === undefined) return err({ kind: 'bad-shape', path, detail: `groups[${i}] needs a string label` });
-    const declared = declareGroup(map, { id: id.value, label, layer: layer.value });
-    if (!declared.ok) return err({ kind: 'invariant-violation', path, violation: declared.error });
-    map = declared.value;
-  }
-
-  for (const [i, rawNode] of asArray(raw['nodes']).entries()) {
-    if (!isRecord(rawNode)) return err({ kind: 'bad-shape', path, detail: `nodes[${i}] is not an object` });
-    const id = makeNodeId(String(rawNode['id'] ?? ''));
-    if (!id.ok) return err({ kind: 'invariant-violation', path, violation: id.error });
-    const layer = makeLayerId(String(rawNode['layer'] ?? ''));
-    if (!layer.ok) return err({ kind: 'invariant-violation', path, violation: layer.error });
-    const status = makeNodeStatus(String(rawNode['status'] ?? ''));
-    if (!status.ok) return err({ kind: 'invariant-violation', path, violation: status.error });
-    const label = optionalString(rawNode['label']);
-    if (label === undefined) return err({ kind: 'bad-shape', path, detail: `nodes[${i}] needs a string label` });
-
-    const detail = optionalString(rawNode['detail']);
-    const rawGroup = optionalString(rawNode['group']);
-    let group;
-    if (rawGroup !== undefined) {
-      const made = makeGroupId(rawGroup);
-      if (!made.ok) return err({ kind: 'invariant-violation', path, violation: made.error });
-      group = made.value;
-    }
-    const rawNodeKind = optionalString(rawNode['kind']);
-    let nodeKind;
-    if (rawNodeKind !== undefined) {
-      const made = makeNodeKind(rawNodeKind);
-      if (!made.ok) return err({ kind: 'invariant-violation', path, violation: made.error });
-      nodeKind = made.value;
-    }
-    const rawLane = optionalString(rawNode['lane']);
-    let lane;
-    if (rawLane !== undefined) {
-      const made = makeLaneId(rawLane);
-      if (!made.ok) return err({ kind: 'invariant-violation', path, violation: made.error });
-      lane = made.value;
-    }
-    const rawSubmap = optionalString(rawNode['submap']);
-    let submap;
-    if (rawSubmap !== undefined) {
-      const made = makeSubmapRef(rawSubmap);
-      if (!made.ok) return err({ kind: 'invariant-violation', path, violation: made.error });
-      submap = made.value;
-    }
-    const declared = declareNode(map, {
-      id: id.value,
-      label,
-      layer: layer.value,
-      status: status.value,
-      ...(detail !== undefined ? { detail } : {}),
-      ...(group !== undefined ? { group } : {}),
-      ...(nodeKind !== undefined ? { kind: nodeKind } : {}),
-      ...(lane !== undefined ? { lane } : {}),
-      ...(submap !== undefined ? { submap } : {}),
-    });
-    if (!declared.ok) return err({ kind: 'invariant-violation', path, violation: declared.error });
-    map = declared.value;
-
-    const evidence = optionalString(rawNode['evidence']);
-    if (evidence !== undefined) {
-      const updated = updateNode(map, { id: id.value, evidence });
-      if (!updated.ok) return err({ kind: 'invariant-violation', path, violation: updated.error });
-      map = updated.value;
-    }
-  }
-
-  for (const [i, rawEdge] of asArray(raw['edges']).entries()) {
-    if (!isRecord(rawEdge)) return err({ kind: 'bad-shape', path, detail: `edges[${i}] is not an object` });
-    const from = makeNodeId(String(rawEdge['from'] ?? ''));
-    if (!from.ok) return err({ kind: 'invariant-violation', path, violation: from.error });
-    const to = makeNodeId(String(rawEdge['to'] ?? ''));
-    if (!to.ok) return err({ kind: 'invariant-violation', path, violation: to.error });
-    const linked = linkNodes(map, from.value, to.value, optionalString(rawEdge['label']));
-    if (!linked.ok) return err({ kind: 'invariant-violation', path, violation: linked.error });
-    map = linked.value;
-  }
-
-  return ok(map);
-}
-
-/** Serialize a map into the on-disk shape. Inverse of parseMap for valid maps. */
-export function serializeMap(map: MellosMap): string {
-  const body = {
-    version: STATE_FILE_VERSION,
-    ...(map.title !== undefined ? { title: map.title } : {}),
-    ...(map.kind !== undefined ? { kind: map.kind } : {}),
-    layers: map.layers,
-    ...(map.lanes.length > 0 ? { lanes: map.lanes } : {}),
-    ...(map.groups.length > 0 ? { groups: map.groups } : {}),
-    nodes: map.nodes,
-    edges: map.edges,
-  };
-  return JSON.stringify(body, null, 2) + '\n';
-}
-
 /** Load and validate the map file at `path`. */
 export function loadMapFile(path: string): Result<MellosMap, StoreError> {
   let text: string;

--- a/src/watch/watch.test.ts
+++ b/src/watch/watch.test.ts
@@ -254,9 +254,9 @@ describe('diagram kinds in the panel', () => {
 });
 
 describe('sub-map hierarchy — interior pages are not sibling tabs', () => {
-  const DEFAULT = '/p/.claude/mellos-mapping.json';
-  const child = '/p/.claude/mellos-mapping.pages/core-internals.json';
-  const effort = '/p/.claude/mellos-mapping.pages/new-effort.json';
+  const DEFAULT = '/p/.mellos/map.json';
+  const child = '/p/.mellos/pages/core-internals.json';
+  const effort = '/p/.mellos/pages/new-effort.json';
 
   function overview(): MellosMap {
     let map = sample();

--- a/src/watch/watch.ts
+++ b/src/watch/watch.ts
@@ -43,8 +43,9 @@ import { realpathSync, statSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-import { groupStatus, mapStatus } from '../domain/ops.js';
+import { mapStatus } from '../domain/ops.js';
 import { type MellosMap, type NodeStatus } from '../domain/types.js';
+import { type NeighborRef, diveParent, focusInfo, mostRecentKey, submapRefs } from '../semantics/semantics.js';
 import {
   type BoxHit,
   type ZoomStep,
@@ -157,16 +158,7 @@ export function mostRecentPageFile(
   files: readonly string[],
   mtimeOf: (file: string) => number | undefined,
 ): string | undefined {
-  let best: string | undefined;
-  let bestMtime = -Infinity;
-  for (const file of files) {
-    const mtime = mtimeOf(file);
-    if (mtime !== undefined && mtime > bestMtime) {
-      best = file;
-      bestMtime = mtime;
-    }
-  }
-  return best ?? files[0];
+  return mostRecentKey(files, mtimeOf);
 }
 
 const HIDE_CURSOR = '\x1b[?25l';
@@ -376,10 +368,7 @@ export function topLevelFiles(
   files: readonly string[],
   mapOf: ReadonlyMap<string, MellosMap | undefined>,
 ): string[] {
-  const refs = new Set<string>();
-  for (const m of mapOf.values()) {
-    for (const n of m?.nodes ?? []) if (n.submap !== undefined) refs.add(n.submap as string);
-  }
+  const refs = submapRefs(mapOf.values());
   return files.filter((f) => {
     const id = pageIdOfFile(defaultFile, f);
     return id === undefined || !refs.has(id as string);
@@ -399,12 +388,8 @@ export function diveOrigin(
 ): { parent: string; label: string } | undefined {
   const id = pageIdOfFile(defaultFile, file);
   if (id === undefined) return undefined;
-  for (const f of files) {
-    if (f === file) continue;
-    const node = mapOf.get(f)?.nodes.find((n) => (n.submap as string | undefined) === (id as string));
-    if (node !== undefined) return { parent: f, label: node.label };
-  }
-  return undefined;
+  const entries = files.filter((f) => f !== file).map((f) => [f, mapOf.get(f)] as const);
+  return diveParent(entries, id as string);
 }
 
 /** The hit whose center is nearest to (cx, cy) by Manhattan distance. */
@@ -442,34 +427,16 @@ export function nodePanel(
 ): PanelLine[] | undefined {
   const g = (s: NodeStatus): string => STATUS_GLYPH[s][unicode ? 0 : 1];
   const pinMark = pinned ? (unicode ? '  ⊙ pinned' : '  * pinned') : '';
+  const focus = focusInfo(map, focusId);
+  if (focus === undefined) return undefined;
+  const refText = (r: NeighborRef): string =>
+    `${g(r.status)} ${r.label}${r.edgeLabel !== undefined ? ` (${r.edgeLabel})` : ''}`;
 
-  const group = map.groups.find((gr) => (gr.id as string) === focusId);
-  if (group) {
-    const members = map.nodes.filter((n) => n.group === group.id);
-    const memberIds = new Set(members.map((n) => n.id as string));
-    const status = groupStatus(map, group.id);
-    const layerName = map.layers.find((l) => l.id === group.layer)?.name ?? (group.layer as string);
+  if (focus.kind === 'group') {
+    const { group, status, layerName, members } = focus;
     const [right, left] = unicode ? ['→', '←'] : ['->', '<-'];
-    // A neighbour is shown as its own group when it has one, else as itself.
-    const repLabel = (id: string): string => {
-      const n = map.nodes.find((x) => (x.id as string) === id)!;
-      const owner = n.group !== undefined ? map.groups.find((gr) => gr.id === n.group) : undefined;
-      return owner !== undefined ? `${g(groupStatus(map, owner.id))} ${owner.label}` : `${g(n.status)} ${n.label}`;
-    };
-    const uses = [
-      ...new Set(
-        map.edges
-          .filter((e) => memberIds.has(e.from as string) && !memberIds.has(e.to as string))
-          .map((e) => repLabel(e.to as string)),
-      ),
-    ];
-    const usedBy = [
-      ...new Set(
-        map.edges
-          .filter((e) => memberIds.has(e.to as string) && !memberIds.has(e.from as string))
-          .map((e) => repLabel(e.from as string)),
-      ),
-    ];
+    const uses = focus.uses.map(refText);
+    const usedBy = focus.usedBy.map(refText);
     const lines: PanelLine[] = [
       {
         text: fitWidth(
@@ -489,28 +456,19 @@ export function nodePanel(
     return lines.slice(0, rows);
   }
 
-  const node = map.nodes.find((n) => (n.id as string) === focusId);
-  if (!node) return undefined;
+  const { node, layerName, laneLabel } = focus;
   const neutral = isNeutralKind(map);
-  const layerName = map.layers.find((l) => l.id === node.layer)?.name ?? (node.layer as string);
   const [right, left] = unicode ? ['→', '←'] : ['->', '<-'];
-  const withGlyph = (id: string): string => {
-    const n = map.nodes.find((x) => (x.id as string) === id);
-    return n ? `${g(n.status)} ${n.label}` : id;
-  };
   // An edge label rides along in parentheses: what flows between the nodes.
-  const withEdgeLabel = (base: string, label: string | undefined): string =>
-    label !== undefined ? `${base} (${label})` : base;
-  const uses = map.edges.filter((e) => e.from === node.id).map((e) => withEdgeLabel(withGlyph(e.to as string), e.label));
-  const usedBy = map.edges.filter((e) => e.to === node.id).map((e) => withEdgeLabel(withGlyph(e.from as string), e.label));
+  const uses = focus.uses.map(refText);
+  const usedBy = focus.usedBy.map(refText);
 
-  const pin = pinned ? (unicode ? '  ⊙ pinned' : '  * pinned') : '';
+  const pin = pinMark;
   // Documentation kinds hide the status vocabulary: kind glyph (or bullet)
   // instead of the status glyph, no status word, no status color.
   const headGlyph = neutral
     ? (node.kind !== undefined ? kindGlyph(node.kind as string, unicode) : undefined) ?? (unicode ? '·' : '.')
     : g(node.status);
-  const laneLabel = node.lane !== undefined ? map.lanes.find((l) => l.id === node.lane)?.label : undefined;
   const headParts = [
     `${headGlyph} ${node.label} [${node.id}]`,
     layerName,

--- a/src/watch/watch.ts
+++ b/src/watch/watch.ts
@@ -67,6 +67,7 @@ import {
   listPageFiles,
   loadMapFile,
   makePageId,
+  migrateLegacyStore,
   pageFilePath,
   pageIdOfFile,
   takeFocusRequest,
@@ -757,6 +758,8 @@ export function mapPanel(
 
 function main(): void {
   const cfg = parseArgs(process.argv.slice(2), process.cwd());
+  // One-time move of a pre-0.19 `.claude` store into `.mellos` (store.ts).
+  migrateLegacyStore(cfg.file);
   const interactive = process.stdin.isTTY === true && process.stdout.isTTY === true;
   const mouseActive = interactive && cfg.mouse;
 

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": ["src/domain/**/*.ts", "src/store/**/*.ts", "src/semantics/**/*.ts", "src/render/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## What

Two structural moves that turn mellos-mapping from "a Claude Code plugin" into "a tool with three host-neutral contract surfaces" (npm library · MCP server · store layout), consumed identically by Claude Code, Codex, and DeepSeek Harness:

1. **Library surface** — the lower layers are published as subpath exports:
   - `format` split out of `store` (`parseMap`/`serializeMap`, pure of `node:*`, browser-safe by test),
   - medium-neutral view semantics hoisted out of the terminal renderer into `semantics` (zoom ladder, `aggregateMap`, `flipForSequence`, `focusInfo`, `submapRefs`, `diveParent`, `mostRecentKey`),
   - `exports` map (`./domain/types`, `./domain/ops`, `./format`, `./store`, `./semantics`, `./render`) backed by a `tsc` lib build, with a browser-safety gate walking the pure entries' import closure.
   The terminal pane re-consumes the library; its behavior is proven byte-identical by the existing snapshot suite.

2. **Host-neutral store** — the map's home moves from `.claude/mellos-mapping.*` to the tool-owned **`.mellos/`** (`map.json`, `pages/<slug>.json`, `focus`). The old path coupled the data to one host brand, which turned absurd once other hosts drove the same server. `migrateLegacyStore` moves a pre-0.19 store exactly once — explicitly from the server/watcher entry points, never merging into a non-empty new store — with three migration specs. Every doc, skill, command, and launcher follows. The `.claude-plugin/` packaging manifest is Claude Code's distribution convention, not data, and stays.

## Compatibility

- **Upgrade path**: first run of the 0.19 server or watcher in a project migrates its legacy store automatically. Projects tracking map files in git will see the move as delete+add; `.gitignore` patterns naming the old path need a one-line update.
- **Mixed-version caution**: a 0.15 host and a 0.19 host driving the *same project simultaneously* will split-brain (old writes `.claude`, new reads `.mellos`). Upgrade all hosts on a machine together.
- Tool schemas and pane behavior are unchanged.

## Verification

- 186/186 tests (library layers, server, watcher snapshots, 3 migration specs).
- Downstream proof: DeepSeek Harness consumes the library for its native web map view and reads the same store through these exports; its host seam derives store paths from the library constants and passes its own suites against this branch.

## Version

`0.19.0-dev.0` on this branch; releasing `0.19.0` (npm + plugin marketplace in one bump) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
