### PR TITLE
Document the DeepSeek Harness install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 English | [简体中文](README.zh-CN.md)
 
-A live, terminal-native map of bottom-up development for
-[Claude Code](https://claude.com/claude-code) and Codex CLI.
+A live map of bottom-up development — a terminal pane beside
+[Claude Code](https://claude.com/claude-code) and Codex CLI, a native web
+panel inside [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness).
 
 <p align="center">
   <picture>
@@ -137,6 +138,54 @@ off), or start with `--no-follow`. Elsewhere run
 `node <plugin root>/dist/watch.mjs` (same `--page` / `--no-follow` flags)
 from the project directory in a second terminal (or any terminal split).
 
+## DeepSeek Harness
+
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`)
+renders the map as a **native web panel** — conversation on the left, live
+map column on the right. There is no terminal pane here and nothing to
+launch: the panel ships inside dsh itself (its `mmap` package family, built
+on this package's browser-safe library exports) and watches the workspace
+store directly. The only thing to install from this repo is the MCP server.
+
+dsh enables no MCP server out of the box — a server command is trusted code
+outside the agent sandbox — so you opt in through a user patch layer. Add
+this entry to `~/.dsh/cordis.patch.yml` (`$DSH_HOME`; applies to every
+profile on the machine) or `~/.dsh/profiles/<name>/cordis.patch.yml` (one
+profile):
+
+```yaml
+- insert:
+    - id: mcp-mellos-mapping
+      name: '@deepseek-ai/dsh-mcp-client'
+      config:
+        serverName: mellos-mapping
+        transport: stdio
+        command: npx
+        args: ['-y', 'mellos-mapping']
+        workspaceScoped: true
+```
+
+`@deepseek-ai/dsh-mcp-client` ships with the dsh CLI; the tools reach the
+model as `mcp__mellos-mapping__mmap_*`.
+
+`workspaceScoped: true` is load-bearing. One dsh process hosts many
+sessions across many workspaces, so this flag makes the bridge route each
+tool call to a server child spawned in the **calling session's** workspace —
+every project's map lands in its own `.mellos/`, exactly where Claude Code
+and Codex write it. Without the flag a single server would write every
+session's map into whatever directory dsh happened to start from.
+
+In the web view the map column opens by itself the first time the map
+changes; the **Map** button in the conversation header toggles it any time.
+Zoom, pan, page tabs and sub-map dives work as in the terminal pane, and
+the viewpoint is remembered **per conversation**.
+
+The mapping discipline is a skill under Claude Code and Codex; dsh
+discovers user skills in `~/.dsh/skills/`. To have the same discipline on
+tap, drop an `mmap.md` there — start from this repo's
+[`skills/mellos-mapping/SKILL.md`](skills/mellos-mapping/SKILL.md) and cut
+its terminal-pane instructions, which do not apply.
+
 ## Any MCP client
 
 The server ships on npm, so any MCP client (Cursor, Windsurf, Zed,
@@ -154,7 +203,7 @@ npx -y -p mellos-mapping mellos-mapping-watch
 ```
 
 The skill/discipline layer is Claude Code + Codex specific; other clients
-get the four `mmap_*` tools and the pane, and bring their own prompting.
+get the five `mmap_*` tools and the pane, and bring their own prompting.
 
 ## Use
 
@@ -277,7 +326,7 @@ first time the assistant declares a map — the reply nudges it to ask you):
 - `complex` — map only medium or complex tasks (the default until configured).
 - `on-request` — map only when you explicitly ask.
 
-The choice is stored in `.claude/mellos-mapping.config.json` and guides the
+The choice is stored in `.mellos/config.json` and guides the
 assistant; it never blocks the tools, and asking for a map explicitly always
 works under any policy.
 
@@ -303,7 +352,7 @@ The repo is itself layered bottom-up, and each layer has its spec:
 | 1 store | `src/store/store.ts` | atomic state-file persistence on Node |
 | 1 semantics | `src/semantics/` | medium-neutral view semantics: zoom ladder, group aggregation, sequence flip |
 | 2 apply | `src/server/apply.ts` | tool inputs → transactional op sequences |
-| 3 server | `src/server/server.ts` | the four MCP tools over stdio |
+| 3 server | `src/server/server.ts` | the five MCP tools over stdio |
 | 4 render | `src/render/`, `src/watch/` | ASCII renderer and the polling pane |
 
 `dist/` is committed deliberately: plugin installation clones this repo and

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,8 +4,10 @@
 
 [English](README.md) | 简体中文
 
-给 [Claude Code](https://claude.com/claude-code) 与 Codex CLI 的自下而上
-开发实况地图，原生运行在终端里。
+自下而上开发的实况地图——在 [Claude Code](https://claude.com/claude-code)
+与 Codex CLI 旁边是终端分屏，在
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 里是
+原生 web 面板。
 
 <p align="center">
   <picture>
@@ -125,6 +127,49 @@ node ~/.codex/plugins/cache/mellos-mapping/mellos-mapping/<版本>/scripts/codex
 其他环境在项目目录下的第二个终端（或任意分屏）运行
 `node <插件根>/dist/watch.mjs`（同样支持 `--page` / `--no-follow`）。
 
+## DeepSeek Harness
+
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（`dsh`）
+把地图渲染成**原生 web 面板**——对话在左，实况地图列在右。这里没有终端
+分屏，也不需要启动任何东西：面板随 dsh 本体分发（它的 `mmap` 包族，构建
+在本包浏览器安全的库导出之上），直接监视工作区里的地图文件。需要从本仓库
+安装的只有 MCP 服务器。
+
+dsh 默认不启用任何 MCP 服务器——服务器命令是运行在智能体沙箱之外的受信任
+代码——所以要通过用户 patch 层显式接入。把下面的条目加进
+`~/.dsh/cordis.patch.yml`（`$DSH_HOME`；对本机所有 profile 生效）或
+`~/.dsh/profiles/<name>/cordis.patch.yml`（只对一个 profile 生效）：
+
+```yaml
+- insert:
+    - id: mcp-mellos-mapping
+      name: '@deepseek-ai/dsh-mcp-client'
+      config:
+        serverName: mellos-mapping
+        transport: stdio
+        command: npx
+        args: ['-y', 'mellos-mapping']
+        workspaceScoped: true
+```
+
+`@deepseek-ai/dsh-mcp-client` 随 dsh CLI 一起分发；工具以
+`mcp__mellos-mapping__mmap_*` 的名字出现在模型面前。
+
+`workspaceScoped: true` 是关键。一个 dsh 进程承载多个工作区里的多个会话，
+这个开关让桥接层把每次工具调用路由到**发起调用的那个会话**的工作区里拉起
+的服务器子进程——每个项目的地图都落在自己的 `.mellos/` 里，和 Claude
+Code、Codex 写入的位置完全一致。不开它，单个服务器会把所有会话的地图写进
+dsh 恰好启动时所在的目录。
+
+在 web 视图里，本会话工作区的地图第一次发生变化时，地图列会自动展开；
+对话标题栏的「地图」按钮随时开关。缩放、平移、多页标签、子图下潜与终端
+分屏一致，且视角**按会话**各自记忆。
+
+建图纪律在 Claude Code 和 Codex 下是 skill；dsh 会从 `~/.dsh/skills/`
+发现用户技能。想在 dsh 里也随手可用，就放一份 `mmap.md` 进去——以本仓库
+的 [`skills/mellos-mapping/SKILL.md`](skills/mellos-mapping/SKILL.md) 为
+底稿，删掉其中不适用的终端分屏部分即可。
+
 ## 任意 MCP 客户端
 
 服务器已发布到 npm，任何 MCP 客户端（Cursor、Windsurf、Zed、Gemini
@@ -141,7 +186,7 @@ npx -y mellos-mapping
 npx -y -p mellos-mapping mellos-mapping-watch
 ```
 
-技能/纪律层是 Claude Code 与 Codex 专属的；其他客户端获得四个 `mmap_*`
+技能/纪律层是 Claude Code 与 Codex 专属的；其他客户端获得五个 `mmap_*`
 工具和面板，提示词自备。
 
 ## 使用
@@ -253,7 +298,7 @@ npx -y -p mellos-mapping mellos-mapping-watch
 - `complex` —— 只在中等或复杂任务时建图（未配置时的默认行为）。
 - `on-request` —— 只在你明确要求时建图。
 
-选择保存在 `.claude/mellos-mapping.config.json`，用于引导 AI；它从不阻止
+选择保存在 `.mellos/config.json`，用于引导 AI；它从不阻止
 工具本身——无论什么策略，明确要求建图永远有效。
 
 工具强制的结构不变量：层按 rank 构成全序；每个节点恰好属于一层；边**严格
@@ -276,7 +321,7 @@ npm run verify   # 类型检查 + 测试 + 打包
 | 1 store | `src/store/store.ts` | Node 上的原子化状态文件持久化 |
 | 1 semantics | `src/semantics/` | 媒介无关的视图语义：缩放阶梯、分组聚合、时序翻转 |
 | 2 apply | `src/server/apply.ts` | 工具输入 → 事务性操作序列 |
-| 3 server | `src/server/server.ts` | stdio 上的四个 MCP 工具 |
+| 3 server | `src/server/server.ts` | stdio 上的五个 MCP 工具 |
 | 4 render | `src/render/`、`src/watch/` | ASCII 渲染器和轮询面板 |
 
 `dist/` 是刻意提交的：插件安装就是克隆本仓库、不运行任何东西，所以入口


### PR DESCRIPTION
## What

The READMEs covered Claude Code, Codex CLI, and generic MCP clients — but not [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness), whose integration works differently from every terminal host. Both READMEs (EN + zh-CN) gain a **DeepSeek Harness** section between Codex CLI and Any MCP client, and the tagline now names all three hosts.

The section documents:

- dsh renders the map as a **native web panel** (its `mmap` package family, built on this package's browser-safe library exports) — no terminal pane, no watcher; the only thing installed from this repo is the MCP server.
- The patch-layer entry (`~/.dsh/cordis.patch.yml` or per-profile) bridging the server through `@deepseek-ai/dsh-mcp-client` with `npx -y mellos-mapping`.
- Why `workspaceScoped: true` is load-bearing: one dsh process hosts many sessions across many workspaces; the flag routes each tool call to a server child spawned in the calling session's workspace, so every project's map lands in its own `.mellos/` — the same location Claude Code and Codex write.
- Panel behavior: auto-opens on first map activity, Map header button toggles, viewpoint remembered per conversation.
- Discipline as a skill: dsh discovers user skills in `~/.dsh/skills/`; start from `skills/mellos-mapping/SKILL.md` minus the terminal-pane parts.

## Drive-by corrections

Two facts had drifted in both languages:

- `mmap_setup` made it **five** tools, not four (two spots each).
- The mapping-policy file lives at `.mellos/config.json` since the store re-homing (#3); the setup section still said `.claude/mellos-mapping.config.json`.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)